### PR TITLE
Improvements to automatic tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ php:
 
 # WordPress versions
 env:
-    - WP_VERSION=3.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=3.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
     - WP_VERSION=4.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
     - WP_VERSION=4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
     - WP_VERSION=4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ language: php
 # PHP Versions
 php:
     - 5.6
+    - 7.0
     - 7.1
     - 7.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,54 @@
-language: php
-php:
-- 5.3
-- 5.4
-- 5.5
-- 5.6
+# Travis CI Configuration File
+
+# Use Travis CI container-based infrastructure
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
+
+# Tell Travis CI we're using PHP
+language: php
+
+# PHP Versions
+php:
+    - 5.6
+    - 7.1
+    - 7.2
+
+# WordPress versions
 env:
-- WP_VERSION=4.1.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=3.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=3.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.4 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.6 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+
 branches:
-  only:
-  - master
+    only:
+        - master
+
 before_script:
-- export SLUG=$(basename $(pwd))
-- svn co --quiet http://develop.svn.wordpress.org/tags/$WP_VERSION $WP_CORE_DIR
-- cd ..
-- mv $SLUG "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
-- cd $WP_CORE_DIR
-- mysql -e "CREATE DATABASE wordpress_tests;" -uroot
-- cp wp-tests-config-sample.php wp-tests-config.php
-- sed -i "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/src/':" wp-tests-config.php
-- sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
-- sed -i "s/yourusernamehere/travis/" wp-tests-config.php
-- sed -i "s/yourpasswordhere//" wp-tests-config.php
-- mv wp-tests-config.php "$WP_TESTS_DIR/wp-tests-config.php"
-- cd "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
+    - export SLUG=$(basename $(pwd))
+    - svn co --quiet http://develop.svn.wordpress.org/tags/$WP_VERSION $WP_CORE_DIR
+    - cd ..
+    - mv $SLUG "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
+    - cd $WP_CORE_DIR
+    - mysql -e "CREATE DATABASE wordpress_tests;" -uroot
+    - cp wp-tests-config-sample.php wp-tests-config.php
+    - sed -i "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/src/':" wp-tests-config.php
+    - sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
+    - sed -i "s/yourusernamehere/travis/" wp-tests-config.php
+    - sed -i "s/yourpasswordhere//" wp-tests-config.php
+    - mv wp-tests-config.php "$WP_TESTS_DIR/wp-tests-config.php"
+    - cd "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
+
 script: phpunit
+
 notifications:
   slack:
     secure: Iji+RK3PdJbN1/aMBEnLxJ+D1LJCd9wOe7ka+y5TtFq8EMZXy8S/m8IxS+mqSvZUOhGwfgBXL9jsyCPVkqpkNNwY/34QDC8iQQU8e10TpVuD5YUfSOo6Fa/RtQik1gYUFbrxt9OCt4CaMEcyDdVTNb5A/cIoisaqk5xmCeXSvJc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,23 +8,60 @@ sudo: false
 language: php
 
 # PHP Versions
-php:
-    - 5.6
-    - 7.0
-    - 7.1
-    - 7.2
+# php:
+#     - 5.6
+#     - 7.0
+#     - 7.1
+#     - 7.2
+#
+# # WordPress versions
+# env:
+#     - WP_VERSION=4.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.4 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.6 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
 
-# WordPress versions
-env:
-    - WP_VERSION=4.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.4 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.6 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+# for a breakdown of why these versions were chosen,
+# see https://github.com/INN/WP-DS-NPR-API/issues/12#issuecomment-374730094
+# or the commit message that introduced this change
+
+matrix:
+    include:
+      # PHPUnit 5
+      - php: 5.6
+        env: WP_VERSION=4.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.4 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.6 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 6
+      - php: 7.0
+        env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.0
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 6
+      - php: 7.1
+        env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.1
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 7 not supported by WordPress
 
 branches:
     only:

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -152,11 +152,11 @@ function pmp_get_pmp_attachments($parent_id) {
  * @since 0.1
  */
 function pmp_verify_settings() {
-	$options = get_option('pmp_settings');
+	$options = get_option( 'pmp_settings' );
 	return (
-		!empty($options['pmp_api_url']) &&
-		!empty($options['pmp_client_id']) &&
-		!empty($options['pmp_client_secret'])
+		! empty( $options['pmp_api_url'] ) &&
+		! isset( $options['pmp_client_id'] ) &&
+		! isset( $options['pmp_client_secret'] )
 	);
 }
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -75,12 +75,12 @@ function pmp_client_id_input() {
  * @since 0.1
  */
 function pmp_client_secret_input() {
-	$options = get_option('pmp_settings');
+	$options = get_option( 'pmp_settings' );
 
-	if (empty($options['pmp_client_secret'])) { ?>
-		<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />
-	<?php } else { ?>
+	if ( ! empty( $options ) && ! empty( $options['pmp_client_secret'] ) ) { ?>
 		<a href="#" id="pmp_client_secret_reset">Change client secret</a>
+	<?php } else { ?>
+		<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />
 	<?php }
 }
 /**

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -116,6 +116,7 @@ class TestFunctions extends WP_UnitTestCase {
 					empty( $value ),
 					isset( $value )
 				);
+				print( $output );
 				error_log(var_export( $output, true));
 			}
 		}

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -100,13 +100,10 @@ class TestFunctions extends WP_UnitTestCase {
 	function test_pmp_verify_settings() {
 		// Since we're setting the pmp_settings in bootstrap.php, this
 		// test should return true
-		$this->assertTrue(
-			pmp_verify_settings(),
-			'Either pmp_verify_settings() is broken, or the option value pmp_settings is not properly set by tests/bootstrap.php. Does your test-runner have the appropriate environment variables configured?'
-		);
+		$bool = pmp_verify_settings();
 
 		// but on the off chance that it doesn't, we'll want some more information
-		if ( ! pmp_verify_settings() ) {
+		if ( true !== $bool ) {
 			$settings = get_option( 'pmp_settings' );
 			foreach ( $settings as $key => $value ) {
 				$output = sprintf(
@@ -116,10 +113,15 @@ class TestFunctions extends WP_UnitTestCase {
 					empty( $value ),
 					isset( $value )
 				);
-				print( $output );
-				error_log(var_export( $output, true));
+				$this->assertEmpty( $output, $key );
 			}
 		}
+
+		$this->assertTrue(
+			$bool,
+			'Either pmp_verify_settings() is broken, or the option value pmp_settings is not properly set by tests/bootstrap.php. Does your test-runner have the appropriate environment variables configured?'
+		);
+
 	}
 
 	function test_pmp_on_post_status_transition() {

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -100,7 +100,10 @@ class TestFunctions extends WP_UnitTestCase {
 	function test_pmp_verify_settings() {
 		// Since we're setting the pmp_settings in bootstrap.php, this
 		// should return true
-		$this->assertTrue(pmp_verify_settings());
+		$this->assertTrue(
+			pmp_verify_settings(),
+			'Either pmp_verify_settings() is broken, or the option value pmp_settings is not properly set by tests/bootstrap.php. Does your test-runner have the appropriate environment variables configured?'
+		);
 	}
 
 	function test_pmp_on_post_status_transition() {

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -124,7 +124,7 @@ class TestFunctions extends WP_UnitTestCase {
 				);
 				$array[$key] = $output;
 			}
-			$this->assertEmpty( $array, 'This is debug information for test_pmp_verify_settings' );
+			$this->assertEquals( array(), $array, 'This is debug information for test_pmp_verify_settings: ' . var_export( $array, true ) );
 		}
 	}
 

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -100,11 +100,20 @@ class TestFunctions extends WP_UnitTestCase {
 	function test_pmp_verify_settings() {
 		// Since we're setting the pmp_settings in bootstrap.php, this
 		// test should return true
-		$bool = pmp_verify_settings();
+		$this->assertTrue(
+			pmp_verify_settings(),
+			'Either pmp_verify_settings() is broken, or the option value pmp_settings is not properly set by tests/bootstrap.php. Does your test-runner have the appropriate environment variables configured?'
+		);
 
+	}
+
+	function test_pmp_verify_settings_more() {
+		$bool = pmp_verify_settings();
+		// this is for additional debug information, should pmp_verify_settings be false
 		// but on the off chance that it doesn't, we'll want some more information
 		if ( true !== $bool ) {
 			$settings = get_option( 'pmp_settings' );
+			$array = array();
 			foreach ( $settings as $key => $value ) {
 				$output = sprintf(
 					'%1$s: "%2$s" long, empty "%3$s", isset "%4$s"',
@@ -113,15 +122,10 @@ class TestFunctions extends WP_UnitTestCase {
 					empty( $value ),
 					isset( $value )
 				);
-				$this->assertEmpty( $output, $key );
+				$array[$key] = $output;
 			}
+			$this->assertEmpty( $array, 'This is debug information for test_pmp_verify_settings' );
 		}
-
-		$this->assertTrue(
-			$bool,
-			'Either pmp_verify_settings() is broken, or the option value pmp_settings is not properly set by tests/bootstrap.php. Does your test-runner have the appropriate environment variables configured?'
-		);
-
 	}
 
 	function test_pmp_on_post_status_transition() {

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -99,11 +99,26 @@ class TestFunctions extends WP_UnitTestCase {
 
 	function test_pmp_verify_settings() {
 		// Since we're setting the pmp_settings in bootstrap.php, this
-		// should return true
+		// test should return true
 		$this->assertTrue(
 			pmp_verify_settings(),
 			'Either pmp_verify_settings() is broken, or the option value pmp_settings is not properly set by tests/bootstrap.php. Does your test-runner have the appropriate environment variables configured?'
 		);
+
+		// but on the off chance that it doesn't, we'll want some more information
+		if ( ! pmp_verify_settings() ) {
+			$settings = get_option( 'pmp_settings' );
+			foreach ( $settings as $key => $value ) {
+				$output = sprintf(
+					'%1$s: "%2$s" long, empty "%3$s", isset "%4$s"',
+					$key,
+					strlen( $value ),
+					empty( $value ),
+					isset( $value )
+				);
+				error_log(var_export( $output, true));
+			}
+		}
 	}
 
 	function test_pmp_on_post_status_transition() {

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -87,7 +87,7 @@ class TestFunctions extends WP_UnitTestCase {
 
 	function test_pmp_media_sideload_image() {
 		$new_post = $this->factory->post->create();
-		$url = 'http://publicmediaplatform.org/wp-content/uploads/logo1.png';
+		$url = 'http://blog.apps.npr.org/img/nprlogo.gif';
 		$desc = 'Test description';
 
 		$image_id = pmp_media_sideload_image($url, $new_post, $desc);
@@ -173,7 +173,7 @@ class TestFunctions extends WP_UnitTestCase {
 
 	function test_pmp_enclosures_for_media() {
 		$new_post = $this->factory->post->create();
-		$url = 'http://publicmediaplatform.org/wp-content/uploads/logo1.png';
+		$url = 'http://blog.apps.npr.org/img/nprlogo.gif';
 		$desc = 'Test description';
 
 		$image_id = pmp_media_sideload_image($url, $new_post, $desc);

--- a/tests/inc/test-settings.php
+++ b/tests/inc/test-settings.php
@@ -80,8 +80,35 @@ class TestSettings extends WP_UnitTestCase {
 		pmp_client_id_input();
 	}
 
-	function test_pmp_client_secret_input() {
+	/**
+	 * Same as test_pmp_client_secret_input_option, but with an option saved
+	 *
+	 * @see test_pmp_client_secret_input_option
+	 * @see pmp_client_secret_input
+	 */
+	function test_pmp_client_secret_input_nooption() {
+		// save the PMP settings that exist at this point in the test
+		$preserve = get_option( 'pmp_settings' );
+
+		update_option( 'pmp_settings', null );
 		$expect = '/<a href="#" id="pmp_client_secret_reset">Change client secret<\/a>/';
+		$this->expectOutputRegex($expect);
+		pmp_client_secret_input();
+
+		// reset
+		update_option( 'pmp_settings', $preserve );
+	}
+
+	/**
+	 * Expectation is valid in the case that `$options['pmp_client_secret']` is not empty
+	 * where `$options = get_option('pmp_settings')`.
+	 *
+	 * @see test_pmp_client_secret_input_nooption
+	 * @see pmp_client_secret_input
+	 */
+	function test_pmp_client_secret_input_option() {
+		$expect = preg_quote( '<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />' , '/' );
+		$expect = '/' . $expect . '/';
 		$this->expectOutputRegex($expect);
 		pmp_client_secret_input();
 	}

--- a/tests/inc/test-settings.php
+++ b/tests/inc/test-settings.php
@@ -81,7 +81,8 @@ class TestSettings extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Same as test_pmp_client_secret_input_option, but with an option saved
+	 * Expectation is valid in the case that `$options['pmp_client_secret']` is not empty
+	 * or is unset, where `$options = get_option('pmp_settings')`.
 	 *
 	 * @see test_pmp_client_secret_input_option
 	 * @see pmp_client_secret_input
@@ -91,7 +92,8 @@ class TestSettings extends WP_UnitTestCase {
 		$preserve = get_option( 'pmp_settings' );
 
 		delete_option( 'pmp_settings' );
-		$expect = '/<a href="#" id="pmp_client_secret_reset">Change client secret<\/a>/';
+		$expect = preg_quote( '<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />' , '/' );
+		$expect = '/' . $expect . '/';
 		$this->expectOutputRegex($expect);
 		pmp_client_secret_input();
 
@@ -107,10 +109,19 @@ class TestSettings extends WP_UnitTestCase {
 	 * @see pmp_client_secret_input
 	 */
 	function test_pmp_client_secret_input_option() {
-		$expect = preg_quote( '<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />' , '/' );
-		$expect = '/' . $expect . '/';
+		// save the PMP settings that exist at this point in the test
+		$preserve = get_option( 'pmp_settings' );
+
+		update_option( 'pmp_settings', array(
+			'pmp_client_secret' => 'test string',
+		) );
+
+		$expect = '/<a href="#" id="pmp_client_secret_reset">Change client secret<\/a>/';
 		$this->expectOutputRegex($expect);
 		pmp_client_secret_input();
+
+		// reset
+		update_option( 'pmp_settings', $preserve );
 	}
 
 	function test_pmp_settings_validate() {

--- a/tests/inc/test-settings.php
+++ b/tests/inc/test-settings.php
@@ -90,7 +90,7 @@ class TestSettings extends WP_UnitTestCase {
 		// save the PMP settings that exist at this point in the test
 		$preserve = get_option( 'pmp_settings' );
 
-		update_option( 'pmp_settings', null );
+		delete_option( 'pmp_settings' );
 		$expect = '/<a href="#" id="pmp_client_secret_reset">Change client secret<\/a>/';
 		$this->expectOutputRegex($expect);
 		pmp_client_secret_input();


### PR DESCRIPTION
## Changes

`.travis.yml`:
- copies formatting of https://github.com/npr/nprapi-wordpress/blob/master/.travis.yml
- cuts PHP versions down to the four versions that are not yet end-of-life: 5.6, 7.0, 7.1, ~~7.2~~ https://secure.php.net/supported-versions.php
    - previous versions of PHP contain unpatched security flaws
    - 5.6 will stop receiving security updates on 31 December 2018
    - 7.0 will stop receiving security updates on 3 December 2018
- switches WordPress versions to the latest patch release in each release's branch, and extends WordPress versions covered from 4.1 to the current release, 4.9

tests:
- Replaces http://publicmediaplatform.org/wp-content/uploads/logo1.png with http://blog.apps.npr.org/img/nprlogo.gif because the PMP logo image was 301'ing to a non-image URL.
- Adds a separate test for the output of `pmp_client_secret_input` when no PMP options have been saved
- Adds an explanation of why the test `test_pmp_verify_settings` might fail: if your test suite's env vars aren't set in accordance with bootstrap.php
- Patches `test_pmp_client_secret_input_option` so that it will run as intended even if your test suite's env vars aren't set in accordance with bootstrap.php

`pmp_client_secret()`:

- Flips the logic so that the default case is to output the `pmp_client_secret` field, and only output the reset button if the client secret has been saved

## Travis tests update:

This PR expands the versions tested because we want to make sure that the plugin is compatible with recent PHP and WordPress versions. The simple way to do that is to enumerate a list of WordPress versions and a list of PHP versions, and then run the tests at each intersection. Not only is this approach inefficient, it causes problems when old versions of WordPress include a test suite that assumes an old version of PHPUnit, which is not available when Travis CI only offers one version of PHPUnit per PHP version.

Based on research in npr/pmp-php-sdk#36,
Travis CI runs tests using the following PHPUnit versions:

- PHP 5.6: PHPUnit 5.7.23
- PHP 7: PHPUnit 6.4.3
- PHP 7.1: PHPUnit 6.4.3
- PHP 7.2: PHPUnit 7.0.2

Reasons that given versions of WordPress have tests incompatible with travis-ci.org:

1. There are PHP warnings about deprecated PHP-4-style constructors.
2. Requires PHPUnit 5 because PHPUnit 6 support was not included until WordPress 4.7.
3. Unless there's been an update since [this trac thread](https://core.trac.wordpress.org/ticket/39822), WordPress tests still assume PHPUnit 6, and Travis runs PHP 7.2 tests using PHPUnit 7

| phpunit | 5.7 | 6.4 | 6.4 | 7.0 |                 |                  |
|---------|-----|-----|-----|-----|-----------------|------------------|
| **php** | 5.6 | 7.0 | 7.1 | 7.2 |                 |                  |
| **WP**      |     |     |     |     | wp release year | then-current php |
| 4.1     |     | 1   | 1   | 1   | 2014            | 5.5              |
| 4.2     |     | 2   | 2   | 2   | 2015            | 5.6              |
| 4.3     |     | 2   | 2   | 2   | 2015            | 5.6              |
| 4.4     |     | 2   | 2   | 2   | 2015            | 7.0              |
| 4.5     |     | 2   | 2   | 2   | 2016            | 7.0              |
| 4.6     |     | 2   | 2   | 2   | 2016            | 7.0              |
| 4.7     |     | 2   | 2   | 2   | 2016            | 7.1              |
| 4.8     |     |     |     | 3   | 2017            | 7.1              |
| 4.9     |     |     |     | 3   | 2017            | 7.2              |

## Concerns

~~We're going from `( 4 PHP * 1 WordPress ) = 4 builds` to `( 4 PHP * 9 WordPress ) = 36 builds`. builds will take forever to run.~~ After ce1b173, the number of builds is limited to 13.

NPR needs to configure Travis builds as described in [the top comment](https://github.com/npr/pmp-wordpress-plugin/pull/131#issuecomment-373535530) on this pull request in order for tests to pass.

I don't know where the Slack notifications line in `.travis.yml` runs to.