### PR TITLE
Catch a Guzzle runtime exception in the settings page, and warn users that PMP won't work

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -109,7 +109,7 @@ function pmp_user_title_input() {
 		}
 		catch(\Guzzle\Common\Exception\RuntimeException $e ) {
 			printf(
-				'<p style="color:#a94442"><b>%1$s</b></p><pre><code>%2$s</code></pre><p>%2$s</p>',
+				'<p style="color:#a94442"><b>%1$s</b></p><pre><code>%2$s</code></pre><p>%3$s</p>',
 				wp_kses_post( __( 'Unable to connect, for the following reason:', 'pmp' ) ),
 				esc_html( $e->getMessage() ),
 				wp_kses_post( __( 'The Public Media Platform plugin will not work correctly until this error is fixed.', 'pmp' ) )

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -107,6 +107,14 @@ function pmp_user_title_input() {
 		catch (\Pmp\Sdk\Exception\HostException $e) {
 			echo '<p style="color:#a94442"><b>Unable to connect - ' . $options['pmp_api_url'] . ' is unreachable</b></p>';
 		}
+		catch(\Guzzle\Common\Exception\RuntimeException $e ) {
+			printf(
+				'<p style="color:#a94442"><b>%1$s</b></p><pre><code>%2$s</code></pre><p>%2$s</p>',
+				wp_kses_post( __( 'Unable to connect, for the following reason:', 'pmp' ) ),
+				esc_html( $e->getMessage() ),
+				wp_kses_post( __( 'The Public Media Platform plugin will not work correctly until this error is fixed.', 'pmp' ) )
+			);
+		}
 	}
 }
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -112,7 +112,7 @@ function pmp_user_title_input() {
 				'<p style="color:#a94442"><b>%1$s</b></p><pre><code>%2$s</code></pre><p>%3$s</p>',
 				wp_kses_post( __( 'Unable to connect, for the following reason:', 'pmp' ) ),
 				esc_html( $e->getMessage() ),
-				wp_kses_post( __( 'The Public Media Platform plugin will not work correctly until this error is fixed.', 'pmp' ) )
+				wp_kses_post( __( 'The Public Media Platform plugin will not work correctly until this error is fixed. Please contact your server administrator or hosting provider.', 'pmp' ) )
 			);
 		}
 	}


### PR DESCRIPTION
## Changes

- Catches a `\Guzzle\Common\Exception\RuntimeException` exception and displays its message to the user, preventing a broken settings page as described in https://github.com/npr/pmp-wordpress-plugin/issues/128

<img width="1113" alt="screen shot 2018-03-20 at 11 08 16 am" src="https://user-images.githubusercontent.com/1754187/37663167-05c6dd52-2c2f-11e8-9518-bda59616cfe1.png">

## Why

The root cause of #128 is that something has gone wrong with the library that the PMP PHP SDK uses to connect to the API. The reason that that library, Guzzle, is unable to connect to the internet in the specific case described in #128 is because cURL is not installed as a PHP extension on the server in question, but it seems proper to catch all Guzzle runtime exceptions and display the associated error message, along with an prompt to contact the server admin or hosting provider.

The reason that Guzzle is throwing that exception is because the PMP PHP SDK is using an old version of Guzzle that depends upon cURL. For more detail about that, see https://github.com/npr/pmp-php-sdk/issues/34 and https://github.com/npr/pmp-php-sdk/issues/36.