### PR TITLE
Changelog and version number bump for 0.2.11

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: publicmediaplatform, inn_nerds
 Tags: pmp,pubmedia,publicmediaplatform,apm,npr,pri,prx,pbs,media,news
 Requires at least: 3.9
 Tested up to: 4.3
-Stable tag: 0.2.10
+Stable tag: 0.2.11
 License: MIT
 License URI: https://github.com/publicmediaplatform/pmp-wordpress/blob/master/LICENSE
 
@@ -53,6 +53,12 @@ For information on the PMP in general, head to [support.pmp.io](https://support.
 See the [documentation on Github](https://github.com/publicmediaplatform/pmp-wordpress).
 
 == Changelog ==
+
+= 0.2.11 =
+
+- Catches a Guzzle runtime exception that prevents the plugin from working properly, and warn users about the cause. ([#134](https://github.com/npr/pmp-wordpress-plugin/pull/134))
+- Changes the default environment of the plugin to the sandbox environment: new installations of the plugin will not automatically use production credentials ([#132](https://github.com/npr/pmp-wordpress-plugin/pull/132))
+- Improved test coverage. ([#131](https://github.com/npr/pmp-wordpress-plugin/pull/131))
 
 = 0.2.10 =
 

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/publicmediaplatform/pmp-wordpress
  * Description: Integrate your site's content with the <a href="https://support.pmp.io" target="_blank">Public Media Platform</a>.
  * Author: the PMP and INN nerds
- * Version: 0.2.10
+ * Version: 0.2.11
  * Author URI: https://github.com/publicmediaplatform/pmp-wordpress
  * License: MIT
  */


### PR DESCRIPTION
## Changes

- bumps version number to 0.2.11
- adds changelog

This should be merged after #131, and v0.2.11 should be tagged afterwards. https://github.com/npr/pmp-wordpress-plugin/releases