### PR TITLE
Change how PHP 7+ defines PMP_NOTIFICATIONS_SECRET

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -56,6 +56,7 @@ See the [documentation on Github](https://github.com/publicmediaplatform/pmp-wor
 
 = 0.2.11 =
 
+- For PHP 7 compatibility, changes how the `PMP_NOTIFICATIONS_SECRET` constant is defined in order to prevent an "invalid salt" error causing white-screen errors. (Pull request [#144](https://github.com/npr/pmp-wordpress-plugin/pull/144) for [issue #133](https://github.com/npr/pmp-wordpress-plugin/issues/133))
 - Catches a Guzzle runtime exception that prevents the plugin from working properly, and warn users about the cause. ([#134](https://github.com/npr/pmp-wordpress-plugin/pull/134))
 - Changes the default environment of the plugin to the sandbox environment: new installations of the plugin will not automatically use production credentials ([#132](https://github.com/npr/pmp-wordpress-plugin/pull/132))
 - Improved test coverage. ([#131](https://github.com/npr/pmp-wordpress-plugin/pull/131))

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -1,6 +1,31 @@
 <?php
+/**
+ * Notifications handling code
+ */
 
-define('PMP_NOTIFICATIONS_SECRET', crypt(get_bloginfo('url'), wp_salt('auth')));
+/**
+ * Define some constants used in this plugin for notifications
+ */
+if ( 1 > version_compare( phpversion(), '7', '<' ) ) {
+	/*
+	 * The PHP 7 case
+	 *
+	 * This filters the salt value fed to crypt() to make sure that the
+	 * characters passed are what are valid for 
+	 *
+	 * @see https://github.com/npr/pmp-wordpress-plugin/issues/133
+	 */
+	$wp_salt_sanitized = preg_replace( '/[^\.\/0-9A-Za-z]/', '', wp_salt('auth') );
+	define('PMP_NOTIFICATIONS_SECRET', crypt( get_bloginfo( 'url' ), $wp_salt_sanitized ));
+} else {
+	/*
+	 * php versions less than 7
+	 *
+	 * This is unchanged from plugin version 0.2.10, allowing PHP 5 sites
+	 * to continue using their existing notification secret.
+	 */
+	define('PMP_NOTIFICATIONS_SECRET', crypt(get_bloginfo('url'), wp_salt('auth')));
+}
 define('PMP_NOTIFICATIONS_HUB', 'notifications');
 define('PMP_NOTIFICATIONS_TOPIC_UPDATED', 'topics/updated');
 define('PMP_NOTIFICATIONS_TOPIC_DELETED', 'topics/deleted');


### PR DESCRIPTION
## Changes

This filters the salt provided to crypt() under PHP 7. 

This implements the "hybrid" approach described at https://github.com/npr/pmp-wordpress-plugin/issues/133#issuecomment-384469661, for https://github.com/npr/pmp-wordpress-plugin/issues/133.

## Why

The reason that we must filter the salt value in PHP 7 is to make sure it's limited to the character set `./0-9A-Za-z`, since having any other character in the salt will cause crypt() to fail with the following message, as seen in Travis CI tests:

> Deprecated: crypt(): Supplied salt is not valid for DES. Possible bug in provided salt format. in /tmp/wordpress/src/wp-content/plugins/pmp-wordpress-plugin/inc/notifications.php on line 3

PHP 5 environments do not have this limitation.