### PR TITLE
Allow sites to unset their PMP Secret without resorting to database edits

### DIFF
--- a/assets/js/pmp-options.js
+++ b/assets/js/pmp-options.js
@@ -1,9 +1,18 @@
 (function() {
     var $ = jQuery;
 
-    $('a#pmp_client_secret_reset').click(function() {
-        var tmpl = _.template($('#pmp_client_secret_input_tmpl').html());
-        $(this).parent().append(tmpl());
-        $(this).remove();
+    $('button#pmp_client_secret_reset_button').click(function(e) {
+        e.preventDefault();
+        $('#mode-change').addClass('hidden');
+        $('#mode-reset').removeClass('hidden').children('[disabled]').prop('disabled', false).addClass('to-disable');
+        $('#pmp_client_secret_reset').attr('checked', true);
+        $('#pmp_client_secret').focus();
+    });
+    $('button#pmp_client_secret_reset_reset').click(function(e) {
+        e.preventDefault();
+        $('#mode-change').removeClass('hidden');
+        $('#pmp_client_secret').val('');
+        $('#pmp_client_secret_reset').prop('checked', false).val('');
+        $('#mode-reset').addClass('hidden').children('.to-disable').prop('disabled', true);
     });
 })();

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -80,7 +80,6 @@ function pmp_client_id_input() {
  */
 function pmp_client_secret_input() {
 	$options = get_option( 'pmp_settings' );
-	error_log(var_export( $options, true));
 
 	if (
 		! array_key_exists( 'pmp_client_secret', $options )
@@ -163,10 +162,6 @@ function pmp_user_title_input() {
 function pmp_settings_validate( $input ) {
 	$errors = false;
 	$options = get_option( 'pmp_settings' );
-	error_log(var_export( array(
-		'options' => $options,
-		'input' => $input
-	), true));
 
 	/*
 	 * The logic behind when the value of the secret shall change.

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -69,7 +69,7 @@ function pmp_api_url_input() {
 function pmp_client_id_input() {
 	$options = get_option( 'pmp_settings' );
 	?>
-		<input id="pmp_client_id" name="pmp_settings[pmp_client_id]" type="text" value="<?php echo esc_attr( $options['pmp_client_id'] ); ?>" />
+		<input id="pmp_client_id" name="pmp_settings[pmp_client_id]" type="text" value="<?php echo esc_attr( $options['pmp_client_id'] ); ?>" style="width: 25em; max-width: 100%;" />
 	<?php
 }
 
@@ -80,11 +80,40 @@ function pmp_client_id_input() {
  */
 function pmp_client_secret_input() {
 	$options = get_option( 'pmp_settings' );
+	error_log(var_export( $options, true));
 
-	if ( ! empty( $options ) && ! empty( $options['pmp_client_secret'] ) ) { ?>
-		<a href="#" id="pmp_client_secret_reset">Change client secret</a>
+	if (
+		! array_key_exists( 'pmp_client_secret', $options )
+		|| (
+			array_key_exists( 'pmp_client_secret', $options )
+			&& empty( $options['pmp_client_secret'] )
+		)
+	) { ?>
+		<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" style="width: 25em; max-width: 100%;" />
 	<?php } else { ?>
-		<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />
+		<div id="mode-change">
+			<button id="pmp_client_secret_reset_button" class="button">Change client secret</button>
+		</div>
+		<div id="mode-reset" class="hidden">
+			<input disabled id="pmp_client_secret_reset" name="pmp_settings[pmp_client_secret_reset]" type="checkbox" value="reset" style="display:none;"/>
+			<label for="pmp_client_secret_reset" class="hidden" >
+				<?php
+					echo wp_kses_post( __( 'Check this box if you are currently changing the client secret.', 'pmp' ) );
+				?>
+			</label>
+
+			<input disabled id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" style="width: 25em; max-width: 100%;" />
+			<label for="pmp_client_secret" style="display: block; clear: both; margin: 4px 0;">
+				<?php
+					echo wp_kses_post( __( 'If left blank, this form will unset the saved PMP Client Secret.', 'pmp' ) );
+				?>
+			</label>
+			<button disabled id="pmp_client_secret_reset_reset" class="button">
+				<?php
+					echo wp_kses_post( __( 'Cancel', 'pmp' ) );
+				?>
+			</button>
+		</div>
 	<?php }
 }
 /**
@@ -134,10 +163,97 @@ function pmp_user_title_input() {
 function pmp_settings_validate( $input ) {
 	$errors = false;
 	$options = get_option( 'pmp_settings' );
+	error_log(var_export( array(
+		'options' => $options,
+		'input' => $input
+	), true));
 
-	if ( empty( $input['pmp_client_secret'] ) && ! empty( $options['pmp_client_secret'] ) ) {
+	/*
+	 * The logic behind when the value of the secret shall change.
+	 *
+	 * The value for $options['pmp_client_secret'] has these possible values:
+	 * - unset (array key does not exist)
+	 * - empty
+	 * - not-empty, aka "set"
+	 *
+	 * $input['pmp_client_secret'] can be:
+	 * - unset
+	 * - empty
+	 * - set
+	 *
+	 * The checkbox $input['pmp_client_secret_reset'], which indicates that the
+	 * value of the option should be overwritten by the value of the input,
+	 * can have these possible values from the form pmp_client_secret_input():
+	 * - 'reset': checked
+	 * - unset: unchecked
+	 *
+	 * This results in a 3x3x2 matrix of possible setups.
+	 * Well, we can simplify the $input['pmp_client_secret'] to set/not, so
+	 * it's really a 3x2x2 matrix of 12 possible settings.
+	 *
+	 * Here's my notes on when we should change, and when changing results in no effective change
+	 * - option unset
+	 *     - box checked
+	 *         - input not set: change results in no change
+	 *         - input set: change results in desired change
+	 *     - box unchecked
+	 *         - input not set: change undesired
+	 *         - input set: change undesired
+	 * - option empty
+	 *     - box checked
+	 *         - input not set: change results in no change
+	 *         - input set: change results in desired change
+	 *     - box unchecked
+	 *         - input not set: change undesired
+	 *         - input set: change undesired
+	 * - option set
+	 *     - box checked
+	 *         - input not set: change results in desired change of unsetting the set option, for #130
+	 *         - input set: change results in desired change
+	 *     - box unchecked
+	 *         - input not set: change undesired
+	 *         - input set: change undesired
+	 *
+	 * This cannot be reduced to:
+	 * - box unchecked
+	 *     - keep option
+	 * - box checked
+	 *     - input empty: unset option
+	 *     - input set: update option
+	 * because the inital state of the plugin's form is that the value is unset and the box is unchecked.
+	 *
+	 * This can be reduced to:
+	 * - option unset/empty
+	 *      - accept input
+	 * - option set
+	 *      - box checked: accept input
+	 * - else: keep old input
+	 *
+	 * It could be reduced further, but would lose readability and thinkability.
+	 */
+	if (
+		! isset ( $options['pmp_client_secret'] )
+		|| empty ( $options['pmp_client_secret'] )
+	) {
+		$input['pmp_client_secret'] = $input['pmp_client_secret'];
+	} elseif (
+		isset( $options['pmp_client_secret'] )
+		&& ! empty( $options['pmp_client_secret'] )
+		&& isset( $input['pmp_client_secret_reset'] )
+		&& 'reset' === $input['pmp_client_secret_reset']
+	) {
+		$input['pmp_client_secret'] = $input['pmp_client_secret'];
+	} else {
 		$input['pmp_client_secret'] = $options['pmp_client_secret'];
 	}
+
+	// cleanup options that are empty.
+	if ( empty( $input['pmp_client_secret'] ) ) {
+		unset( $input['pmp_client_secret'] );
+	}
+
+	// this does not need to be saved, ever.
+	unset( $input['pmp_client_secret_reset'] );
 
 	if ( ! empty( $input['pmp_api_url'] ) && false == filter_var( $input['pmp_api_url'], FILTER_VALIDATE_URL ) ) {
 		add_settings_error( 'pmp_settings_fields', 'pmp_api_url_error', 'Please enter a valid PMP API URL.', 'error' );

--- a/plugin.php
+++ b/plugin.php
@@ -7,6 +7,7 @@
  * Version: 0.2.11
  * Author URI: https://github.com/publicmediaplatform/pmp-wordpress
  * License: MIT
+ * Text Domain: pmp
  */
 
 // check if plugin is composer-installed

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -10,8 +10,4 @@
 			<input type="submit" name="submit" id="submit" class="button button-primary" value="Save Changes">
 		</p>
 	</form>
-
-	<script type="text/template" id="pmp_client_secret_input_tmpl">
-		<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" />
-	</script>
 </div>


### PR DESCRIPTION
## Changes

This implements the "alternate solution" described in
https://github.com/npr/pmp-wordpress-plugin/issues/130,
whereby the PMP client secret's value is never passed to the browser,
but the browser can unset the PMP client secret's value by passing
an empty value with the form while also passing a checked box stating
intent to change the value.

## Screenshots

The unconfigured plugin, the same as the plugin which has had a secret unset:
<img width="650" alt="screen shot 2018-09-25 at 2 02 48 am" src="https://user-images.githubusercontent.com/1754187/45995745-63016380-c067-11e8-82ca-4e0e8265a4db.png">

The configured plugin
<img width="695" alt="screen shot 2018-09-25 at 2 03 13 am" src="https://user-images.githubusercontent.com/1754187/45995746-63016380-c067-11e8-9081-50d983e6693c.png">

Click the "change" button:
<img width="664" alt="screen shot 2018-09-25 at 2 04 03 am" src="https://user-images.githubusercontent.com/1754187/45995747-63016380-c067-11e8-80c7-0ee5b8916b8e.png">

A new secret entered
<img width="631" alt="screen shot 2018-09-25 at 2 04 13 am" src="https://user-images.githubusercontent.com/1754187/45995748-6399fa00-c067-11e8-86bf-d061fbef5fab.png">


## Why

Prior to this pull request, if a site wanted to outright unset their client secret for any reason, they would have to resort to editing the `wp_options` table directly to remove the client secret. The logic for handing the settings page was structured as described in #130, preventing the user from entering an empty value for the secret that would thereby unset the secret.

This adds a hidden input to track user intent-to-change for the secret, and considers the intent-to-change indicator when determining whether to replace an empty value for the secret with the saved secret in the form submission.

## Questions

- [ ] Does the really long comment in function pmp_settings_validate() in inc/settings.php make sense?
- [ ] Do any docs in this plugin's Github repo need to be updated to accommodate this change? https://github.com/npr/pmp-wordpress-plugin/blob/master/README.md
- [ ] How are tests? Note that this PR will experience PHP 7 test issues because https://github.com/npr/pmp-wordpress-plugin/pull/143 hasn't been merged yet, but do we pass in PHP 5?