### PR TITLE
Contains a bunch of fixes:

### DIFF
--- a/inc/class-sdkwrapper.php
+++ b/inc/class-sdkwrapper.php
@@ -12,6 +12,14 @@ class SDKWrapper {
 	public function __construct() {
 		$settings = get_option('pmp_settings');
 
+		if (
+			! isset( $settings['pmp_api_url'] )
+			|| ! isset( $settings['pmp_client_id'] )
+			|| ! isset( $settings['pmp_client_secret'] )
+		) {
+			throw new Pmp\Sdk\Exception\AuthException( 'need to set the API URL, client ID, or client secret' );
+		}
+
 		$this->sdk = new \Pmp\Sdk(
 			$settings['pmp_api_url'],
 			$settings['pmp_client_id'],
@@ -20,7 +28,11 @@ class SDKWrapper {
 	}
 
 	public function __call($name, $args) {
-		return call_user_func_array(array($this->sdk, $name), $args);
+		if ( is_a( $this->sdk, 'Pmp\Sdk' ) ) {
+			return call_user_func_array(array($this->sdk, $name), $args);
+		} else {
+			return false;
+		}
 	}
 
 	/**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -447,14 +447,15 @@ function pmp_get_my_guid() {
 	$pmp_my_guid_transient_key = 'pmp_my_guid';
 	$pmp_my_guid_transient = get_transient($pmp_my_guid_transient_key);
 
-	if (!empty($pmp_my_guid_transient))
+	if ( ! empty( $pmp_my_guid_transient ) ) {
 		return $pmp_my_guid_transient;
+	}
 
 	$sdk = new SDKWrapper();
-	$me = $sdk->fetchUser('me');
+	$me = $sdk->fetchUser( 'me' );
 
 	$pmp_my_guid_transient = $me->attributes->guid;
-	set_transient($pmp_my_guid_transient_key, $pmp_my_guid_transient, 0);
+	set_transient( $pmp_my_guid_transient_key, $pmp_my_guid_transient, 0 );
 	return $pmp_my_guid_transient;
 }
 

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -185,7 +185,7 @@ function pmp_subscription_verification($data) {
 
 	$settings = get_option('pmp_settings');
 
-	if (isset($settings['pmp_use_api_notifications']) && $settings['pmp_use_api_notifications'] == 'on')
+	if (isset($settings['pmp_use_api_notifications']) && 'on' === $settings['pmp_use_api_notifications'] )
 		$mode = 'unsubscribe';
 	else
 		$mode = 'subscribe';

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -229,10 +229,12 @@ function pmp_settings_validate( $input ) {
 	 * It could be reduced further, but would lose readability and thinkability.
 	 */
 	if (
-		! isset ( $options['pmp_client_secret'] )
-		|| empty ( $options['pmp_client_secret'] )
+		! isset( $options['pmp_client_secret'] )
+		|| empty( $options['pmp_client_secret'] )
 	) {
-		$input['pmp_client_secret'] = $input['pmp_client_secret'];
+		if ( isset( $input['pmp_client_secret'] ) ) {
+			$input['pmp_client_secret'] = $input['pmp_client_secret'];
+		}
 	} elseif (
 		isset( $options['pmp_client_secret'] )
 		&& ! empty( $options['pmp_client_secret'] )

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -51,12 +51,12 @@ function pmp_use_api_notifications_input() {
  */
 function pmp_api_url_input() {
 	$options = get_option( 'pmp_settings' );
-	$is_sandbox = empty( $options['pmp_api_url'] ) || 'https://api-sandbox.pmp.io' === $options['pmp_api_url'] ;
+	$is_sandbox = empty( $options['pmp_api_url'] ) || 'https://api-sandbox.pmp.io' === $options['pmp_api_url'];
 	$is_production = ! $is_sandbox;
 	?>
 		<select id="pmp_api_url" name="pmp_settings[pmp_api_url]">
-			<option <?php echo $is_production ? 'selected' : '' ; ?> value="https://api.pmp.io">Production</option>
-			<option <?php echo $is_sandbox ? 'selected' : '' ; ?> value="https://api-sandbox.pmp.io">Sandbox</option>
+			<option <?php echo $is_production ? 'selected' : ''; ?> value="https://api.pmp.io">Production</option>
+			<option <?php echo $is_sandbox ? 'selected' : ''; ?> value="https://api-sandbox.pmp.io">Sandbox</option>
 		</select>
 	<?php
 }
@@ -89,7 +89,8 @@ function pmp_client_secret_input() {
 			array_key_exists( 'pmp_client_secret', $options )
 			&& empty( $options['pmp_client_secret'] )
 		)
-	) { ?>
+	) {
+		?>
 		<input id="pmp_client_secret" name="pmp_settings[pmp_client_secret]" type="password" value="" style="width: 25em; max-width: 100%;" />
 	<?php } else { ?>
 		<div id="mode-change">
@@ -115,7 +116,8 @@ function pmp_client_secret_input() {
 				?>
 			</button>
 		</div>
-	<?php }
+	<?php
+	}
 }
 /**
  * Static field for currently connected user
@@ -126,8 +128,7 @@ function pmp_user_title_input() {
 	$options = get_option( 'pmp_settings' );
 	if ( empty( $options['pmp_api_url'] ) || empty( $options['pmp_client_id'] ) || empty( $options['pmp_client_secret'] ) ) {
 		echo '<p><em>Not connected</em></p>';
-	}
-	else {
+	} else {
 		try {
 			$sdk = new SDKWrapper();
 			$me = $sdk->fetchUser( 'me' );
@@ -142,8 +143,7 @@ function pmp_user_title_input() {
 			echo '<p style="color:#a94442"><b>Unable to connect - invalid Client-Id/Secret. Is the correct environment chosen?</b></p>';
 		} catch ( \Pmp\Sdk\Exception\HostException $e ) {
 			echo '<p style="color:#a94442"><b>Unable to connect - ' . esc_html( $options['pmp_api_url'] ) . ' is unreachable</b></p>';
-		}
-		catch(\Guzzle\Common\Exception\RuntimeException $e ) {
+		} catch ( \Guzzle\Common\Exception\RuntimeException $e ) {
 			printf(
 				'<p style="color:#a94442"><b>%1$s</b></p><pre><code>%2$s</code></pre><p>%3$s</p>',
 				wp_kses_post( __( 'Unable to connect, for the following reason:', 'pmp' ) ),
@@ -158,7 +158,7 @@ function pmp_user_title_input() {
  * Field validations
  *
  * @since 0.1
- * @param Array $input The form input that gets passed to all validation functions
+ * @param Array $input The form input that gets passed to all validation functions.
  * @return Array
  */
 function pmp_settings_validate( $input ) {
@@ -257,13 +257,13 @@ function pmp_settings_validate( $input ) {
 	unset( $input['pmp_client_secret_reset'] );
 
 	// Make sure the API URL is a valid URL.
-	if ( ! empty( $input['pmp_api_url'] ) && false == filter_var( $input['pmp_api_url'], FILTER_VALIDATE_URL ) ) {
+	if ( ! empty( $input['pmp_api_url'] ) && false === filter_var( $input['pmp_api_url'], FILTER_VALIDATE_URL ) ) {
 		add_settings_error( 'pmp_settings_fields', 'pmp_api_url_error', 'Please enter a valid PMP API URL.', 'error' );
 		$input['pmp_api_url'] = '';
 		$errors = true;
 	}
 
-	// If trying to enable the API notifications, but the secret or the ID aren't set, don't enable notifications
+	// If trying to enable the API notifications, but the secret or the ID aren't set, don't enable notifications.
 	if (
 		isset( $input['pmp_use_api_notifications'] ) && ! empty( $input['pmp_use_api_notifications'] )
 		&& (
@@ -280,14 +280,14 @@ function pmp_settings_validate( $input ) {
 	}
 
 	if ( ! empty( $input['pmp_use_api_notifications'] ) && ! isset( $options['pmp_use_api_notifications'] ) ) {
-		foreach (pmp_get_topic_urls() as $topic_url) {
-			$result = pmp_send_subscription_request('subscribe', $topic_url);
+		foreach ( pmp_get_topic_urls() as $topic_url ) {
+			$result = pmp_send_subscription_request( 'subscribe', $topic_url );
 			if ( true !== $result ) {
 				add_settings_error( 'pmp_settings_fields', 'pmp_notifications_subscribe_error', $result, 'error' );
 				$errors = true;
 			}
 		}
-	} else if ( empty( $input['pmp_use_api_notifications'] ) && isset( $options['pmp_use_api_notifications'] ) ) {
+	} elseif ( empty( $input['pmp_use_api_notifications'] ) && isset( $options['pmp_use_api_notifications'] ) ) {
 		foreach ( pmp_get_topic_urls() as $topic_url ) {
 			$result = pmp_send_subscription_request( 'unsubscribe', $topic_url );
 			if ( true !== $result ) {

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -254,13 +254,27 @@ function pmp_settings_validate( $input ) {
 	// this does not need to be saved, ever.
 	unset( $input['pmp_client_secret_reset'] );
 
+	// Make sure the API URL is a valid URL.
 	if ( ! empty( $input['pmp_api_url'] ) && false == filter_var( $input['pmp_api_url'], FILTER_VALIDATE_URL ) ) {
 		add_settings_error( 'pmp_settings_fields', 'pmp_api_url_error', 'Please enter a valid PMP API URL.', 'error' );
 		$input['pmp_api_url'] = '';
 		$errors = true;
-	} else {
-		add_settings_error( 'pmp_settings_fields', 'pmp_settings_updated', 'PMP settings successfully updated!', 'updated' );
-		$errors = true;
+	}
+
+	// If trying to enable the API notifications, but the secret or the ID aren't set, don't enable notifications
+	if (
+		isset( $input['pmp_use_api_notifications'] ) && ! empty( $input['pmp_use_api_notifications'] )
+		&& (
+			empty( $input['pmp_client_id'] )
+			||
+			(
+				empty( $options['pmp_client_secret'] )
+				||
+				empty( $input['pmp_client_secret'] )
+			)
+		)
+	) {
+		unset( $input['pmp_use_api_notifications'] );
 	}
 
 	if ( ! empty( $input['pmp_use_api_notifications'] ) && ! isset( $options['pmp_use_api_notifications'] ) ) {


### PR DESCRIPTION
## Changes

- Better AuthException handling
- Don't save the checkbox for enabling notifications if the URL, ID and secret are not set.
- Fix for undefined constant REQUEST_TIME: This appears to only be a thing in Drupal?
- SDKWrapper now returns false when the SDK is not initialized properly

## Why

Working towards addressing the following email-reported issues:

> I removed the client id and secret to test the “you are not configured” message and got a white screen.
> 
> Is master the branch I should be testing and Ben, have you successfully pushed content to PMP? And received the “config the settings” message when unconfigured?

> Warning: require(phar:///var/www/html/wp-content/plugins/pmp-wordpress-plugin-142-pmp-php-sdk-2/vendor/pmpsdk.phar/Pmp/Sdk.php): failed to open stream: phar error: invalid url or non-existent phar “phar:///var/www/html/wp-content/plugins/pmp-wordpress-plugin-142-pmp-php-sdk-2/vendor/pmpsdk.phar/Pmp/Sdk.php” in phar:///var/www/html/wp-content/plugins/pmp-wordpress-plugin-142-pmp-php-sdk-2/vendor/pmpsdk.phar/autoloader.php on line 109

> Fatal error: require(): Failed opening required ‘phar:///var/www/html/wp-content/plugins/pmp-wordpress-plugin-142-pmp-php-sdk-2/vendor/pmpsdk.phar/Pmp/Sdk.php’ (include_path=‘.:/usr/share/php’) in phar:///var/www/html/wp-content/plugins/pmp-wordpress-plugin-142-pmp-php-sdk-2/vendor/pmpsdk.phar/autoloader.php on line 109