### PR TITLE
Changes to SDKWrapper to make sure it's called with the correct settings 

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory": "assets/js/vendor"
+  "directory": "assets/js/vendor",
+  "registry": "https://registry.bower.io"
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Use this plugin to integrate the [Public Media Platform](http://publicmediaplatform.org/) with WordPress. Integration includes pulling stories and other content from the PMP into WordPress drafts and posts, and pushing WordPress posts into the PMP. Define simple or advanced searches for PMP content and save custom searches for reuse, with or without autopublishing on your WordPress site. Create PMP Groups, Properties, and Series from the plugin and push them to the PMP. Use of this plugin requires that you [register for a PMP account to get API keys](https://support.pmp.io/register).
 
-Also see this project in the [official Wordpress plugin directory](https://wordpress.org/plugins/public-media-platform/).
+Download this project from the [official Wordpress plugin directory](https://wordpress.org/plugins/public-media-platform/).
 
 Built by the [INN Nerds](http://nerds.inn.org/).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PMP WordPress Plugin
 
-[![Build Status](https://travis-ci.org/publicmediaplatform/pmp-wordpress.svg?branch=master)](https://travis-ci.org/publicmediaplatform/pmp-wordpress)
-[![Latest Release](https://img.shields.io/github/release/publicmediaplatform/pmp-wordpress.svg)](https://github.com/publicmediaplatform/pmp-wordpress/releases/latest)
+[![Build Status](https://travis-ci.org/npr/pmp-wordpress.svg?branch=master)](https://travis-ci.org/npr/pmp-wordpress)
+[![Latest Release](https://img.shields.io/github/release/npr/pmp-wordpress.svg)](https://github.com/npr/pmp-wordpress/releases/latest)
 
 Use this plugin to integrate the [Public Media Platform](http://publicmediaplatform.org/) with WordPress. Integration includes pulling stories and other content from the PMP into WordPress drafts and posts, and pushing WordPress posts into the PMP. Define simple or advanced searches for PMP content and save custom searches for reuse, with or without autopublishing on your WordPress site. Create PMP Groups, Properties, and Series from the plugin and push them to the PMP. Use of this plugin requires that you [register for a PMP account to get API keys](https://support.pmp.io/register).
 

--- a/README.txt
+++ b/README.txt
@@ -36,6 +36,8 @@ Built by the [INN Nerds](http://nerds.inn.org/).
 
 == Installation ==
 
+Installation through WordPress.org's plugin repository:
+
 1. Register for your PMP account at https://support.pmp.io/register
 2. Install the Public Media Platform plugin via the Wordpress.org plugin directory
 3. Activate the plugin
@@ -43,7 +45,9 @@ Built by the [INN Nerds](http://nerds.inn.org/).
 5. Enter your PMP Credentials
 6. Away you go!
 
-For more information on plugin setup and usage, see the [PMP-Wordpress Github project](https://github.com/publicmediaplatform/pmp-wordpress#pmp-wordpress).
+For manual installation instructions, see [these instructions on manual installation](https://github.com/npr/pmp-wordpress-plugin/blob/master/docs/installation-development.md).
+
+For more information on plugin setup and usage, see the [PMP-Wordpress Github project](https://github.com/npr/pmp-wordpress-plugin#pmp-wordpress-plugin).
 
 For information on the PMP in general, head to [support.pmp.io](https://support.pmp.io).
 

--- a/docs/installation-development.md
+++ b/docs/installation-development.md
@@ -1,0 +1,17 @@
+# Installation instructions for development
+
+These instructions apply to you if you have:
+
+- downloaded the plugin's raw source code zip files from GitHub
+- cloned the plugin's source code from GitHub
+- deleted the plugin's `vendor/` or `assets/js/vendor` directories
+
+You will need the following prerequisites:
+
+- [composer](https://getcomposer.org/)
+- [bower](https://bower.io/)
+
+To install this plugin after acquiring the source code:
+
+- Run `composer install`
+- Run `bower update`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,3 +15,5 @@ To use the PMP WordPress plugin, you'll need to specify a **Client ID** and **Cl
 ![Settings](/assets/img/largo-PMP-settings-blank.png)
 
 If you don't yet have a Client ID and Client Secret, you'll probably need to [request an account with the PMP](https://support.pmp.io/register).
+
+The option to enable the PMP API to send content updates is disabled until you have saved API credentials for the plugin.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,10 +1,10 @@
-#Installation and Settings for the WordPress PMP Plugin
+# Installation and Settings for the WordPress PMP Plugin
 
 ## Installation
 
 Follow the standard WordPress procedure for [automatic plugin installation](https://codex.wordpress.org/Managing_Plugins#Automatic_Plugin_Installation), and search for "PMP" or "Public Media Platform".  Using the [official plugin](https://wordpress.org/plugins/public-media-platform/) from the Wordpress plugin directory allows you to automatically get updates.
 
-If you'd prefer the bleeding edge `master` version of the plugin, you'll have to install it manually, following the standard procedure for [manual plugin installation](http://codex.wordpress.org/Managing_Plugins#Manual_Plugin_Installation).  You can get the [latest code zip here](https://github.com/publicmediaplatform/phpsdk/archive/master.zip).
+If you'd prefer the bleeding edge `master` version of the plugin, you'll have to install it manually, following the instructions in this plugin's [development install docs](./installation-development.md). You can get the [latest code zip here](https://github.com/publicmediaplatform/phpsdk/archive/master.zip), or by running `git clone https://github.com/npr/pmp-wordpress-plugin.git` in your WordPress plugins directory.
 
 Once the plugin files are installed, activate the plugin via the WordPress dashboard.
 

--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -181,7 +181,6 @@ function pmp_save_users() {
 	if ( pmp_are_settings_valid( $options ) ) {
 		$sdk = new SDKWrapper( $options );
 	} else {
-		header("HTTP/1.0 500 Internal Server Error");
 		print json_encode(array(
 			"message" => "Plugin must be configured before performing this query.",
 			"success" => false

--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -349,7 +349,12 @@ function pmp_get_select_options() {
 	$type = $data['type'];
 
 	$ret = _pmp_select_for_post($post, $type);
-	print json_encode(array_merge(array("success" => true), $ret));
+
+	if ( empty( $ret ) ) {
+		print json_encode(array_merge(array("success" => false), $ret));
+	} else {
+		print json_encode(array_merge(array("success" => true), $ret));
+	}
 
 	wp_die();
 }
@@ -441,7 +446,12 @@ function _pmp_select_for_post($post, $type) {
 	);
 
 	$options = get_option( 'pmp_settings' );
-	$sdk = new SDKWrapper( $options );
+	if ( pmp_are_settings_valid( $options ) ) {
+		$sdk = new SDKWrapper( $options );
+	} else {
+		return array();
+	}
+
 	$pmp_things = $sdk->query2json('queryDocs', array(
 		'profile' => $type,
 		'writeable' => 'true',

--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -11,7 +11,8 @@ include_once __DIR__ . '/class-pmppost.php';
 function pmp_search() {
 	check_ajax_referer('pmp_ajax_nonce', 'security');
 
-	$sdk = new SDKWrapper();
+	$options = get_option( 'pmp_settings' );
+	$sdk = new SDKWrapper( $options );
 	$opts = array(
 		'profile' => 'story',
 		'limit' => 10
@@ -144,7 +145,8 @@ function pmp_save_users() {
 
 	$group_data = json_decode(stripslashes($_POST['data']));
 
-	$sdk = new SDKWrapper();
+	$options = get_option( 'pmp_settings' );
+	$sdk = new SDKWrapper( $options );
 	$group = $sdk->fetchDoc($group_data->collection_guid);
 
 	if (!empty($group_data->items_guids)) {
@@ -297,7 +299,8 @@ add_action('wp_ajax_pmp_get_select_options', 'pmp_get_select_options');
 
 /* Helper functions */
 function _pmp_create_doc($type, $data) {
-	$sdk = new SDKWrapper();
+	$options = get_option( 'pmp_settings' );
+	$sdk = new SDKWrapper( $options );
 
 	if (!empty($data->attributes->tags))
 		$data->attributes->tags = SDKWrapper::commas2array($data->attributes->tags);
@@ -309,7 +312,8 @@ function _pmp_create_doc($type, $data) {
 }
 
 function _pmp_modify_doc($data) {
-	$sdk = new SDKWrapper();
+	$options = get_option( 'pmp_settings' );
+	$sdk = new SDKWrapper( $options );
 	$doc = $sdk->fetchDoc($data->attributes->guid);
 
 	if (!empty($data->attributes->tags))
@@ -322,7 +326,8 @@ function _pmp_modify_doc($data) {
 }
 
 function _pmp_ajax_create_post($is_draft=false) {
-	$sdk = new SDKWrapper();
+	$options = get_option( 'pmp_settings' );
+	$sdk = new SDKWrapper( $options );
 
 	// make sure we don't search for a blank string
 	$guid = empty($_POST['pmp_guid']) ? 'nothing' : $_POST['pmp_guid'];
@@ -368,7 +373,8 @@ function _pmp_select_for_post($post, $type) {
 		'type' => $type
 	);
 
-	$sdk = new SDKWrapper();
+	$options = get_option( 'pmp_settings' );
+	$sdk = new SDKWrapper( $options );
 	$pmp_things = $sdk->query2json('queryDocs', array(
 		'profile' => $type,
 		'writeable' => 'true',

--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -61,6 +61,7 @@ add_action('wp_ajax_pmp_search', 'pmp_search');
  * Ajax function to create a draft post based on PMP story
  *
  * @since 0.1
+ * @see _pmp_ajax_create_post
  */
 function pmp_draft_post() {
 	check_ajax_referer('pmp_ajax_nonce', 'security');
@@ -68,7 +69,7 @@ function pmp_draft_post() {
 		wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
 	}
 	else {
-		print json_encode(_pmp_ajax_create_post(true));
+		print json_encode(_pmp_ajax_create_post(true)); // true=draft
 		wp_die();
 	}
 }
@@ -78,6 +79,7 @@ add_action('wp_ajax_pmp_draft_post', 'pmp_draft_post');
  * Ajax function to publish a post based on PMP story
  *
  * @since 0.1
+ * @see _pmp_ajax_create_post
  */
 function pmp_publish_post() {
 	check_ajax_referer('pmp_ajax_nonce', 'security');
@@ -397,9 +399,22 @@ function _pmp_modify_doc($data) {
 	return $doc;
 }
 
+/**
+ * Create a post from a PMP API story
+ *
+ * @param bool $is_draft Whether the created post should be a draft or not.
+ * @return Array An array of data that will be JSON encoded.
+ */
 function _pmp_ajax_create_post($is_draft=false) {
 	$options = get_option( 'pmp_settings' );
-	$sdk = new SDKWrapper( $options );
+	if ( pmp_are_settings_valid( $options ) ) {
+		$sdk = new SDKWrapper( $options );
+	} else {
+		return array(
+			"message" => "Plugin must be configured before performing this query.",
+			"success" => false
+		);
+	}
 
 	// make sure we don't search for a blank string
 	$guid = empty($_POST['pmp_guid']) ? 'nothing' : $_POST['pmp_guid'];

--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -12,7 +12,17 @@ function pmp_search() {
 	check_ajax_referer('pmp_ajax_nonce', 'security');
 
 	$options = get_option( 'pmp_settings' );
-	$sdk = new SDKWrapper( $options );
+	if ( pmp_are_settings_valid( $options ) ) {
+		$sdk = new SDKWrapper( $options );
+	} else {
+		header("HTTP/1.0 500 Internal Server Error");
+		print json_encode(array(
+			"message" => "Plugin must be configured before performing this query.",
+			"success" => false
+		));
+		wp_die();
+	}
+
 	$opts = array(
 		'profile' => 'story',
 		'limit' => 10
@@ -27,8 +37,9 @@ function pmp_search() {
 		$guid = $opts['guid'];
 		unset($opts['guid']);
 		$result = $sdk->query2json('fetchDoc', $guid, $opts);
-	} else
+	} else {
 		$result = $sdk->query2json('queryDocs', $opts);
+	}
 
 	if (!$result) {
 		header("HTTP/1.0 404 Not Found");

--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -308,8 +308,9 @@ function pmp_save_query() {
 			"success" => true,
 			"search_id" => $search_id
 		));
-	} else
+	} else {
 		print json_encode(array("success" => false));
+	}
 
 	wp_die();
 }
@@ -362,7 +363,10 @@ function pmp_get_select_options() {
 }
 add_action('wp_ajax_pmp_get_select_options', 'pmp_get_select_options');
 
-/* Helper functions */
+/*
+ * Helper functions
+ */
+
 function _pmp_create_doc($type, $data) {
 	$options = get_option( 'pmp_settings' );
 	if ( pmp_are_settings_valid( $options ) ) {
@@ -453,6 +457,7 @@ function _pmp_ajax_create_post($is_draft=false) {
  * @param $type (string) The document option to create a select menu for
  * (i.e., 'group', 'property' or 'series').
  * @since 0.3
+ * @return Array The data structure.
  */
 function _pmp_select_for_post($post, $type) {
 	$ret = array(

--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -176,7 +176,17 @@ function pmp_save_users() {
 	$group_data = json_decode(stripslashes($_POST['data']));
 
 	$options = get_option( 'pmp_settings' );
-	$sdk = new SDKWrapper( $options );
+	if ( pmp_are_settings_valid( $options ) ) {
+		$sdk = new SDKWrapper( $options );
+	} else {
+		header("HTTP/1.0 500 Internal Server Error");
+		print json_encode(array(
+			"message" => "Plugin must be configured before performing this query.",
+			"success" => false
+		));
+		wp_die();
+	}
+
 	$group = $sdk->fetchDoc($group_data->collection_guid);
 
 	if (!empty($group_data->items_guids)) {

--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -102,11 +102,21 @@ function pmp_create_group() {
 	$group = json_decode(stripslashes($_POST['group']));
 	$doc = _pmp_create_doc('group', $group);
 
-	print json_encode(array(
-		"success" => true,
-		"data" => SDKWrapper::prepFetchData($doc)
-	));
-	wp_die();
+	if ( false === $doc ) {
+		print json_encode(array(
+			"success" => false,
+			"data" => false,
+			"message" => "Plugin must be configured before performing this query.",
+		));
+		wp_die();
+	} else {
+		print json_encode(array(
+			"success" => true,
+			"data" => SDKWrapper::prepFetchData($doc)
+		));
+		wp_die();
+	}
+
 }
 add_action('wp_ajax_pmp_create_group', 'pmp_create_group');
 

--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -131,11 +131,20 @@ function pmp_modify_group() {
 	$group = json_decode(stripslashes($_POST['group']));
 	$doc = _pmp_modify_doc($group);
 
-	print json_encode(array(
-		"success" => true,
-		"data" => SDKWrapper::prepFetchData($doc)
-	));
-	wp_die();
+	if ( false === $doc ) {
+		print json_encode(array(
+			"success" => false,
+			"data" => false,
+			"message" => "The document could not be modified",
+		));
+		wp_die();
+	} else {
+		print json_encode(array(
+			"success" => true,
+			"data" => SDKWrapper::prepFetchData($doc)
+		));
+		wp_die();
+	}
 }
 add_action('wp_ajax_pmp_modify_group', 'pmp_modify_group');
 

--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -221,11 +221,20 @@ function pmp_create_collection() {
 	$collection = json_decode(stripslashes($_POST['collection']));
 	$doc = _pmp_create_doc($_POST['profile'], $collection);
 
-	print json_encode(array(
-		"success" => true,
-		"data" => SDKWrapper::prepFetchData($doc)
-	));
-	wp_die();
+	if ( false === $doc ) {
+		print json_encode(array(
+			"success" => false,
+			"data" => false,
+			"message" => "The collection could not be created.",
+		));
+		wp_die();
+	} else {
+		print json_encode(array(
+			"success" => true,
+			"data" => SDKWrapper::prepFetchData($doc)
+		));
+		wp_die();
+	}
 }
 add_action('wp_ajax_pmp_create_collection', 'pmp_create_collection');
 
@@ -240,11 +249,20 @@ function pmp_modify_collection() {
 	$collection = json_decode(stripslashes($_POST['collection']));
 	$doc = _pmp_modify_doc($collection);
 
-	print json_encode(array(
-		"success" => true,
-		"data" => SDKWrapper::prepFetchData($doc)
-	));
-	wp_die();
+	if ( false === $doc ) {
+		print json_encode(array(
+			"success" => false,
+			"data" => false,
+			"message" => "The collection could not be modified.",
+		));
+		wp_die();
+	} else {
+		print json_encode(array(
+			"success" => true,
+			"data" => SDKWrapper::prepFetchData($doc)
+		));
+		wp_die();
+	}
 }
 add_action('wp_ajax_pmp_modify_collection', 'pmp_modify_collection');
 
@@ -340,7 +358,11 @@ add_action('wp_ajax_pmp_get_select_options', 'pmp_get_select_options');
 /* Helper functions */
 function _pmp_create_doc($type, $data) {
 	$options = get_option( 'pmp_settings' );
-	$sdk = new SDKWrapper( $options );
+	if ( pmp_are_settings_valid( $options ) ) {
+		$sdk = new SDKWrapper( $options );
+	} else {
+		return false;
+	}
 
 	if (!empty($data->attributes->tags))
 		$data->attributes->tags = SDKWrapper::commas2array($data->attributes->tags);
@@ -353,7 +375,12 @@ function _pmp_create_doc($type, $data) {
 
 function _pmp_modify_doc($data) {
 	$options = get_option( 'pmp_settings' );
-	$sdk = new SDKWrapper( $options );
+	if ( pmp_are_settings_valid( $options ) ) {
+		$sdk = new SDKWrapper( $options );
+	} else {
+		return false;
+	}
+
 	$doc = $sdk->fetchDoc($data->attributes->guid);
 
 	if (!empty($data->attributes->tags))

--- a/inc/class-pmppost.php
+++ b/inc/class-pmppost.php
@@ -53,18 +53,26 @@ class PmpPost extends PmpSyncer {
   /**
    * Init when you only know the WP post
    *
+   * This function does not check whether the $options from the options table,
+   * used for constructing the SDKWrapper, are valid, because the lone caller
+   * of this function, pmp_get_updates() is only called by pmp_hourly_cron(),
+   * which checks wether pmp_are_settings_valid().
+   *
    * @param $wp_post - a WP_Post instance
    * @return a new PmpSyncer
+   * @see pmp_get_updates
    */
   public static function fromPost(WP_Post $wp_post) {
-    $options = get_option( 'pmp_settings' );
-    $sdk = new SDKWrapper( $options );
     $guid = get_post_meta($wp_post->ID, 'pmp_guid', true);
-    if ($guid) {
+
+    if ( $guid ) {
+      $options = get_option( 'pmp_settings' );
+      $sdk = new SDKWrapper( $options );
+
       $doc = $sdk->fetchDoc($guid);
+
       return new self($doc, $wp_post); // doc might be null
-    }
-    else {
+    } else {
       return new self(null, $wp_post);
     }
   }

--- a/inc/class-pmppost.php
+++ b/inc/class-pmppost.php
@@ -57,7 +57,8 @@ class PmpPost extends PmpSyncer {
    * @return a new PmpSyncer
    */
   public static function fromPost(WP_Post $wp_post) {
-    $sdk = new SDKWrapper();
+    $options = get_option( 'pmp_settings' );
+    $sdk = new SDKWrapper( $options );
     $guid = get_post_meta($wp_post->ID, 'pmp_guid', true);
     if ($guid) {
       $doc = $sdk->fetchDoc($guid);

--- a/inc/class-pmpsyncer.php
+++ b/inc/class-pmpsyncer.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * A class for syncing PMP-documents to WP-posts
  *

--- a/inc/class-pmpsyncer.php
+++ b/inc/class-pmpsyncer.php
@@ -236,7 +236,8 @@ abstract class PmpSyncer {
    * @return boolean success
    */
   protected function new_doc() {
-    $sdk = new SDKWrapper();
+    $options = get_option( 'pmp_settings' );
+    $sdk = new SDKWrapper( $options );
     $this->doc = $sdk->newDoc('base', array(
       'attributes' => array(
         'title'     => $this->post->post_title,

--- a/inc/class-sdkwrapper.php
+++ b/inc/class-sdkwrapper.php
@@ -30,8 +30,7 @@ class SDKWrapper {
 			$settings_array = get_option('pmp_settings');
 		}
 
-		if ( ! pmp_are_settings_valid( $settings_array ) )
-		) {
+		if ( ! pmp_are_settings_valid( $settings_array ) ) {
 			throw new Pmp\Sdk\Exception\AuthException( 'need to set the API URL, client ID, and/or client secret when constructing a new SDKWrapper' );
 		}
 

--- a/inc/class-sdkwrapper.php
+++ b/inc/class-sdkwrapper.php
@@ -9,21 +9,31 @@ class SDKWrapper {
 
 	public $sdk;
 
-	public function __construct() {
-		$settings = get_option('pmp_settings');
-
+	/**
+	 * Constructor accepts as an argument an array of arguments needed to instantiate the SDK
+	 *
+	 * array(
+	 *     'pmp_api_url' => 'https://api.pmp.io/',
+	 *     'pmp_client_id' => '',
+	 *     'pmp_client_secret' => '',
+	 * );
+	 *
+	 * @param Array $settings_array The array of settings.
+	 */
+	public function __construct( $settings_array ) {
 		if (
-			! isset( $settings['pmp_api_url'] )
-			|| ! isset( $settings['pmp_client_id'] )
-			|| ! isset( $settings['pmp_client_secret'] )
+			empty( $settings_array )
+			|| ! isset( $settings_array['pmp_api_url'] )
+			|| ! isset( $settings_array['pmp_client_id'] )
+			|| ! isset( $settings_array['pmp_client_secret'] )
 		) {
-			throw new Pmp\Sdk\Exception\AuthException( 'need to set the API URL, client ID, or client secret' );
+			throw new Pmp\Sdk\Exception\AuthException( 'need to set the API URL, client ID, and/or client secret when constructing a new SDKWrapper' );
 		}
 
 		$this->sdk = new \Pmp\Sdk(
-			$settings['pmp_api_url'],
-			$settings['pmp_client_id'],
-			$settings['pmp_client_secret']
+			$settings_array['pmp_api_url'],
+			$settings_array['pmp_client_id'],
+			$settings_array['pmp_client_secret']
 		);
 	}
 

--- a/inc/class-sdkwrapper.php
+++ b/inc/class-sdkwrapper.php
@@ -24,12 +24,13 @@ class SDKWrapper {
 	 * @param Array $settings_array The array of settings.
 	 * @throws Pmp\Sdk\Exception\AuthException if not configured.
 	 */
-	public function __construct( $settings_array ) {
-		if (
-			empty( $settings_array )
-			|| ! isset( $settings_array['pmp_api_url'] )
-			|| ! isset( $settings_array['pmp_client_id'] )
-			|| ! isset( $settings_array['pmp_client_secret'] )
+	public function __construct( $settings_array = array() ) {
+		// backwards compatibility: try to fetch settings from database if not explicitly passed
+		if ( empty( $settings_array ) ) {
+			$settings_array = get_option('pmp_settings');
+		}
+
+		if ( ! pmp_are_settings_valid( $settings_array ) )
 		) {
 			throw new Pmp\Sdk\Exception\AuthException( 'need to set the API URL, client ID, and/or client secret when constructing a new SDKWrapper' );
 		}

--- a/inc/class-sdkwrapper.php
+++ b/inc/class-sdkwrapper.php
@@ -7,6 +7,9 @@
  */
 class SDKWrapper {
 
+	/**
+	 * @var Pmp\Sdk
+	 */
 	public $sdk;
 
 	/**
@@ -19,6 +22,7 @@ class SDKWrapper {
 	 * );
 	 *
 	 * @param Array $settings_array The array of settings.
+	 * @throws Pmp\Sdk\Exception\AuthException if not configured.
 	 */
 	public function __construct( $settings_array ) {
 		if (

--- a/inc/cron.php
+++ b/inc/cron.php
@@ -32,6 +32,7 @@ function pmp_get_pmp_posts() {
  * the WP post differs from the PMP Doc. If it does differ, update the post in the WP database.
  *
  * @since 0.1
+ * @see pmp_hourly_cron
  */
 function pmp_get_updates() {
 	pmp_debug('========== pmp_get_updates ==========');

--- a/inc/cron.php
+++ b/inc/cron.php
@@ -49,7 +49,14 @@ function pmp_get_updates() {
  */
 function pmp_import_for_saved_queries() {
 	$search_queries = pmp_get_saved_search_queries();
-	$sdk = new SDKWrapper();
+
+	$options = get_option( 'pmp_settings' );
+	if ( pmp_are_settings_valid( $options ) ) {
+		$sdk = new SDKWrapper( $options );
+	} else {
+		pmp_debug( 'Settings array from options table is not valid for initializing the SDK; aborting.' );
+		return false;
+	}
 
 	foreach ($search_queries as $id => $query_data) {
 		if ($query_data->options->query_auto_create == 'off')

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -451,7 +451,14 @@ function pmp_get_my_guid() {
 		return $pmp_my_guid_transient;
 	}
 
-	$sdk = new SDKWrapper();
+	$options = get_option( 'pmp_settings' );
+	if ( pmp_are_settings_valid( $options ) ) {
+		$sdk = new SDKWrapper( $options );
+	} else {
+		pmp_debug( 'Settings array from options table is not valid for initializing the SDK; aborting.' );
+		return false;
+	}
+
 	$me = $sdk->fetchUser( 'me' );
 
 	$pmp_my_guid_transient = $me->attributes->guid;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -456,7 +456,7 @@ function pmp_get_my_guid() {
 		$sdk = new SDKWrapper( $options );
 	} else {
 		pmp_debug( 'Settings array from options table is not valid for initializing the SDK; aborting.' );
-		return false;
+		return false; // get_transient can return false.
 	}
 
 	$me = $sdk->fetchUser( 'me' );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -377,17 +377,17 @@ function pmp_post_is_mine($post_id) {
 
 	// BACKWARDS COMPATIBILITY: set pmp_last_pushed from pmp_owner
 	$pmp_owner = get_post_meta($post_id, 'pmp_owner', true);
-  if (!empty($pmp_owner)) {
-  	delete_post_meta($post_id, 'pmp_owner');
-    if ($pmp_owner == pmp_get_my_guid()) {
-    	$date = get_post_meta($post_id, 'pmp_modified', true);
-    	$date = $date ? $date : date('c', time());
-      update_post_meta($post_id, 'pmp_last_pushed', $date);
-      return true;
-    }
-  }
+	if (!empty($pmp_owner)) {
+		delete_post_meta($post_id, 'pmp_owner');
+		if ($pmp_owner == pmp_get_my_guid()) {
+			$date = get_post_meta($post_id, 'pmp_modified', true);
+			$date = $date ? $date : date('c', time());
+			update_post_meta($post_id, 'pmp_last_pushed', $date);
+			return true;
+		}
+	}
 
-  return false;
+	return false;
 }
 
 /**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -153,11 +153,7 @@ function pmp_get_pmp_attachments($parent_id) {
  */
 function pmp_verify_settings() {
 	$options = get_option( 'pmp_settings' );
-	return (
-		! empty( $options['pmp_api_url'] ) &&
-		isset( $options['pmp_client_id'] ) &&
-		isset( $options['pmp_client_secret'] )
-	);
+	return pmp_are_settings_valid( $options );
 }
 
 /**

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -73,13 +73,15 @@ add_action('template_redirect', 'pmp_notifications_template_redirect');
  * the options table, this funciton can only be used when options have
  * been saved to the options table.
  *
- * @param $mode string either 'subscribe' or 'unsubscribe'
+ * @param String $mode either 'subscribe' or 'unsubscribe'
+ * @pram String $topic_url That which to subscribe to
+ * @param Array $settings (optional) The settings array to be passed to pmp_are_settings_valid
  * @return boolean|string true on success, or a string error message
  * @since 0.3
  * @uses pmp_post_subscription_data
  */
-function pmp_send_subscription_request($mode='subscribe', $topic_url) {
-	$ret = pmp_post_subscription_data($mode, $topic_url);
+function pmp_send_subscription_request( $mode='subscribe', $topic_url, $settings = array() ) {
+	$ret = pmp_post_subscription_data( $mode, $topic_url, $settings );
 
 	if ( is_wp_error( $ret ) ) {
 		$return = array();
@@ -117,7 +119,7 @@ function pmp_send_subscription_request($mode='subscribe', $topic_url) {
  * @param Array $settings (optional) The settings array to be passed to pmp_are_settings_valid
  * @return WP_Error|Array a WP_Error if the settings aren't right; or the results of a wp_remote_get call: Array or WP_Error.
  */
-function pmp_post_subscription_data($mode, $topic_url, $settings = array() ) {
+function pmp_post_subscription_data( $mode, $topic_url, $settings = array() ) {
 	if ( empty( $settings ) ) {
 		$settings = get_option('pmp_settings');
 	}

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -69,9 +69,14 @@ add_action('template_redirect', 'pmp_notifications_template_redirect');
  * When a user enables/disables PMP notifications service, send a subscription
  * request to the PMP notifications server.
  *
+ * Because pmp_post_subscription_data() draws its settings direct from
+ * the options table, this funciton can only be used when options have
+ * been saved to the options table.
+ *
  * @param $mode string either 'subscribe' or 'unsubscribe'
  * @return boolean|string true on success, or a string error message
  * @since 0.3
+ * @uses pmp_post_subscription_data
  */
 function pmp_send_subscription_request($mode='subscribe', $topic_url) {
 	$ret = pmp_post_subscription_data($mode, $topic_url);
@@ -100,19 +105,27 @@ function pmp_send_subscription_request($mode='subscribe', $topic_url) {
 /**
  * Handle sending the actual subscription data to the hub
  *
- * @since 0.3
+ * This uses Pmp\Sdk directly, without using SDKWrapper.
+ * It also draws options directly from the database.
+ *
+ * This function should only be run when settings are saved in the database.
+ *
+ * @since 0.2.10
+ * @uses pmp_are_settings_valid
+ * @param String $mode 'subscribe' or 'unsubscribe'
+ * @param String $topic_url The topic to receive subscription notifications for
+ * @param Array $settings (optional) The settings array to be passed to pmp_are_settings_valid
+ * @return WP_Error|Array a WP_Error if the settings aren't right; or the results of a wp_remote_get call: Array or WP_Error.
  */
-function pmp_post_subscription_data($mode, $topic_url) {
-	$settings = get_option('pmp_settings');
+function pmp_post_subscription_data($mode, $topic_url, $settings = array() ) {
+	if ( empty( $settings ) ) {
+		$settings = get_option('pmp_settings');
+	}
 	$trimmed = rtrim($settings['pmp_api_url'], '/');
 	$hub_url =  $trimmed . '/' . PMP_NOTIFICATIONS_HUB;
 	$hub_post_url = str_replace('api', 'publish', $trimmed) . '/' . PMP_NOTIFICATIONS_HUB;
 
-	if (
-		! isset( $settings['pmp_api_url'] )
-		|| ! isset( $settings['pmp_client_id'] )
-		|| ! isset( $settings['pmp_client_secret'] )
-	) {
+	if ( ! pmp_are_settings_valid( $settings ) ) {
 		return new WP_Error(
 			'pmp_sdk',
 			__( 'Unable to update subscription data: one or more of pmp_api_url, pmp_client_id, and pmp_client_secret were not set.', 'pmp' )

--- a/inc/pages.php
+++ b/inc/pages.php
@@ -54,7 +54,11 @@ function pmp_manage_saved_searches_page() {
 		'searches' => pmp_get_saved_search_queries()
 	);
 
-	pmp_render_template('saved_searches.php', $context);
+	if ( pmp_verify_settings() ) {
+		pmp_render_template('saved_searches.php', $context);
+	} else {
+		pmp_render_template( 'unconfigured.php', array( 'title' => 'Search the Platform' ) );
+	}
 }
 
 /**
@@ -75,7 +79,7 @@ function pmp_groups_page() {
 	} else {
 		pmp_debug( 'Settings array from options table is not valid for initializing the SDK; aborting.' );
 
-		// @todo: template for this page when settings are not saved
+		pmp_render_template( 'unconfigured.php', array( 'title' => 'PMP Groups &amp; Permissions' ) );
 
 		return false;
 	}
@@ -127,7 +131,7 @@ function pmp_collections_page() {
 	} else {
 		pmp_debug( 'Settings array from options table is not valid for initializing the SDK; aborting.' );
 
-		// @todo: template for this page when there are no options.
+		pmp_render_template( 'unconfigured.php', array( 'title' => 'PMP ' . $name ) );
 
 		return false;
 	}

--- a/inc/pages.php
+++ b/inc/pages.php
@@ -69,7 +69,17 @@ function pmp_groups_page() {
 	if (isset($_POST['pmp-unset-default-group']))
 		delete_option('pmp_default_group');
 
-	$sdk = new SDKWrapper();
+	$options = get_option( 'pmp_settings' );
+	if ( pmp_are_settings_valid( $options ) ) {
+		$sdk = new SDKWrapper( $options );
+	} else {
+		pmp_debug( 'Settings array from options table is not valid for initializing the SDK; aborting.' );
+
+		// @todo: template for this page when settings are not saved
+
+		return false;
+	}
+
 	$pmp_users = $sdk->query2json('queryDocs', array(
 		'profile' => 'user',
 		'limit' => 9999
@@ -111,7 +121,17 @@ function pmp_collections_page() {
 	if (isset($_POST['pmp-unset-default-' . $profile]))
 		delete_option('pmp_default_' . $profile);
 
-	$sdk = new SDKWrapper();
+	$options = get_option( 'pmp_settings' );
+	if ( pmp_are_settings_valid( $options ) ) {
+		$sdk = new SDKWrapper( $options );
+	} else {
+		pmp_debug( 'Settings array from options table is not valid for initializing the SDK; aborting.' );
+
+		// @todo: template for this page when there are no options.
+
+		return false;
+	}
+
 	$pmp_collection = $sdk->query2json('queryDocs', array(
 		'profile' => $profile,
 		'writeable' => 'true',

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -280,17 +280,21 @@ function pmp_settings_validate( $input ) {
 		unset( $input['pmp_use_api_notifications'] );
 	}
 
+	// If enabling the API notifications anew, subscribe to the notificatons API
 	if ( ! empty( $input['pmp_use_api_notifications'] ) && ! isset( $options['pmp_use_api_notifications'] ) ) {
 		foreach ( pmp_get_topic_urls() as $topic_url ) {
-			$result = pmp_send_subscription_request( 'subscribe', $topic_url );
+			// use the new options to subscribe to the Notifications API
+			$result = pmp_send_subscription_request( 'subscribe', $topic_url, $input );
 			if ( true !== $result ) {
 				add_settings_error( 'pmp_settings_fields', 'pmp_notifications_subscribe_error', $result, 'error' );
 				$errors = true;
 			}
 		}
+	// If disabling the API notifications, unsubscribe from the notifications API
 	} elseif ( empty( $input['pmp_use_api_notifications'] ) && isset( $options['pmp_use_api_notifications'] ) ) {
 		foreach ( pmp_get_topic_urls() as $topic_url ) {
-			$result = pmp_send_subscription_request( 'unsubscribe', $topic_url );
+			// use the old options to unsubscribe from the Notifications API
+			$result = pmp_send_subscription_request( 'unsubscribe', $topic_url, $options );
 			if ( true !== $result ) {
 				add_settings_error( 'pmp_settings_fields', 'pmp_notifications_unsubscribe_error', $result, 'error' );
 				$errors = true;

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -35,10 +35,19 @@ add_action( 'admin_init', 'pmp_admin_init' );
 function pmp_use_api_notifications_input() {
 	$options = get_option( 'pmp_settings' );
 	$setting = ( isset( $options['pmp_use_api_notifications'] ) ) ? $options['pmp_use_api_notifications'] : false;
+
+	if ( pmp_are_settings_valid( $options ) ) {
+		$disabled = ' ';
+	} else {
+		$disabled = ' disabled ';
+	}
+
 	?>
 		<input id="pmp_use_api_notifications" type="checkbox"
 			name="pmp_settings[pmp_use_api_notifications]"
-			<?php echo checked( $setting, 'on' ); ?>>Enable</input>
+			<?php echo checked( $setting, 'on' ); ?>
+			<?php echo $disabled; ?>
+			>Enable</input>
 		<p><em>Enabling this option allows the PMP API to push to your site as new story, audio, image, etc. updates become available.<em></p>
 		<p><em>This may help improve performance of your site, especially if you have a large number of imported posts.</em></p>
 <?php

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -299,7 +299,7 @@ function pmp_settings_validate( $input ) {
 	}
 
 	if ( empty( $errors ) ) {
-		pmp_update_my_guid_transient();
+		pmp_update_my_guid_transient( $input );
 	}
 
 	return $input;

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -123,14 +123,15 @@ function pmp_client_secret_input() {
  * Static field for currently connected user
  *
  * @since 0.3
+ * @uses pmp_are_settings_valid
  */
 function pmp_user_title_input() {
 	$options = get_option( 'pmp_settings' );
-	if ( empty( $options['pmp_api_url'] ) || empty( $options['pmp_client_id'] ) || empty( $options['pmp_client_secret'] ) ) {
+	if ( ! pmp_are_settings_valid( $options ) ) {
 		echo '<p><em>Not connected</em></p>';
 	} else {
 		try {
-			$sdk = new SDKWrapper();
+			$sdk = new SDKWrapper( $options );
 			$me = $sdk->fetchUser( 'me' );
 			$title = $me->attributes->title;
 			$link = pmp_get_support_link( $me->attributes->guid );

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -316,6 +316,8 @@ function pmp_settings_validate( $input ) {
  *
  * @param Array $settings The settings to be checked
  * @return Boolean Whether or not the settings is valid.
+ * @since 0.2.12
+ * @link https://github.com/npr/pmp-wordpress-plugin/issues/151
  */
 function pmp_are_settings_valid( $settings_array ) {
 	// If things are not set, false.

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -303,3 +303,30 @@ function pmp_settings_validate( $input ) {
 
 	return $input;
 }
+
+/**
+ * Check whether a given settings array is valid for the purposes of initializing the SDK
+ *
+ * This is a subset of pmp_settings_validate()
+ *
+ * @param Array $settings The settings to be checked
+ * @return Boolean Whether or not the settings is valid.
+ */
+function pmp_are_settings_valid( $settings_array ) {
+	// If things are not set, false.
+	if (
+		empty( $settings_array )
+		|| ! isset( $settings_array['pmp_api_url'] )
+		|| ! isset( $settings_array['pmp_client_id'] )
+		|| ! isset( $settings_array['pmp_client_secret'] )
+	) {
+		return false;
+	}
+
+	// If the API URL is not a valid URL, false.
+	if ( ! empty( $settings_array['pmp_api_url'] ) && false === filter_var( $settings_array['pmp_api_url'], FILTER_VALIDATE_URL ) ) {
+		return false;
+	}
+
+	return true;
+}

--- a/plugin.php
+++ b/plugin.php
@@ -177,9 +177,12 @@ register_deactivation_hook(__FILE__, 'pmp_remove_cron_on_deactivation');
  */
 function pmp_hourly_cron() {
 	$options = get_option('pmp_settings');
-	if (!isset($options['pmp_use_api_notifications']) || $options['pmp_use_api_notifications'] !== 'on')
-		pmp_get_updates();
+	if ( pmp_are_settings_valid( $options ) ) {
+		if ( ! isset( $options['pmp_use_api_notifications'] ) || $options['pmp_use_api_notifications'] !== 'on' ) {
+			pmp_get_updates();
+		}
 
-	pmp_import_for_saved_queries();
+		pmp_import_for_saved_queries();
+	}
 }
 add_action('pmp_hourly_cron', 'pmp_hourly_cron');

--- a/templates/search.php
+++ b/templates/search.php
@@ -73,11 +73,11 @@
 		</form>
 
 		<div id="pmp-search-results"></div>
-	<?php } else { ?>
-		<div id="pmp-incomplete-settings-notice">
-			Please specify an <strong>API URL<strong>, <strong>Client ID</strong>, <strong>Client Secret</strong> via the <a href="<?php echo admin_url('admin.php?page=pmp-options-menu'); ?>">PMP settings page</a>.
-		</div>
-	<?php } ?>
+	<?php
+		} else {
+			pmp_render_template( 'unconfigured.php' );
+		}
+	?>
 </div>
 
 <script type="text/template" id="pmp-search-result-tmpl">

--- a/templates/unconfigured.php
+++ b/templates/unconfigured.php
@@ -1,0 +1,9 @@
+<div class="wrap">
+	<?php if ( isset( $title ) && ! empty( $title ) ) { ?>
+		<h2><?php echo wp_kses_post( $title ); ?></h2>
+	<?php } ?>
+
+	<div id="pmp-incomplete-settings-notice">
+		Please specify an <strong>API URL<strong>, <strong>Client ID</strong>, <strong>Client Secret</strong> via the <a href="<?php echo admin_url('admin.php?page=pmp-options-menu'); ?>">PMP settings page</a>.
+	</div>
+</div>

--- a/tests/PMPSyncerTestCase.php
+++ b/tests/PMPSyncerTestCase.php
@@ -28,7 +28,7 @@ abstract class PMP_SyncerTestCase extends WP_UnitTestCase {
       self::$_sdk_wrapper = false;
     }
     else {
-      self::$_sdk_wrapper = new SDKWrapper();
+      self::$_sdk_wrapper = new SDKWrapper( $settings );
       self::$_pmp_story = self::$_sdk_wrapper->fetchDoc(self::$_pmp_story_guid);
     }
   }

--- a/tests/inc/test-ajax.php
+++ b/tests/inc/test-ajax.php
@@ -10,7 +10,7 @@ class TestAjax extends WP_Ajax_UnitTestCase {
 			$this->skip = true;
 		else {
 			$this->skip = false;
-			$this->sdk_wrapper = new SDKWrapper();
+			$this->sdk_wrapper = new SDKWrapper( $settings );
 
 			// A test query that's all but guaranteed to return at least one result.
 			$this->query = array(

--- a/tests/inc/test-class-sdkwrapper.php
+++ b/tests/inc/test-class-sdkwrapper.php
@@ -9,7 +9,7 @@ class TestSDKWrapper extends WP_UnitTestCase {
 		if (empty($settings['pmp_api_url']) || empty($settings['pmp_client_id']) || empty($settings['pmp_client_secret']))
 			$this->sdk_wrapper = false;
 		else {
-			$this->sdk_wrapper = new SDKWrapper();
+			$this->sdk_wrapper = new SDKWrapper( $settings );
 
 			// A test query that's all but guaranteed to return at least one result.
 			$this->query = array(

--- a/tests/inc/test-cron.php
+++ b/tests/inc/test-cron.php
@@ -10,7 +10,7 @@ class TestCron extends WP_UnitTestCase {
 			$this->skip = true;
 		else {
 			$this->skip = false;
-			$this->sdk_wrapper = new SDKWrapper();
+			$this->sdk_wrapper = new SDKWrapper( $settings );
 
 			// A test query that's all but guaranteed to return at least one result.
 			$this->query = array(

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -10,7 +10,7 @@ class TestFunctions extends WP_UnitTestCase {
 			$this->skip = true;
 		else {
 			$this->skip = false;
-			$this->sdk_wrapper = new SDKWrapper();
+			$this->sdk_wrapper = new SDKWrapper( $settings );
 
 			// A test query that's all but guaranteed to return at least one result.
 			$this->query = array(


### PR DESCRIPTION
## Changes

- The constructor for the `SDKWrapper` class now accepts an option of an array, specifying the client ID, client secret, and API URL to use with the PMP SDK. If this is not set, the `SDKWrapper` will try to fetch those settings from the database. If the settings are not valid, as judged by the new function `pmp_are_settings_valid( $settings )`, the `SDKWrapper will throw a `Pmp\Sdk\Exception\AuthException`.
- New function `pmp_are_settings_valid( $settings )` can be sued to determine whether settings are valid, by a number of criteria. This function does *not* attempt to connect to the API, create an instance of `SDKWrapper`, or create an instance of `Pmp\Sdk`
- Wherever functions call `new SDKWrapper`, make sure that an options array is passed. If the options array that would be passed is invalid in the sights of `pmp_are_settings_valid( $options )`, instead of calling `new SDKWrapper( $options )`, fail gracefully:
    - `pmp_search()`'s output is JSON encoding a failure message, with a `500 Internal Server Error` to complement the `404 Not Found` header sent when the search has no results
    - `pmp_save_users()`'s output is JSON encoding a failure message
    - `_pmp_create_doc( $type, $data )` returns false
    - `_pmp_modify_doc( $data )` returns false
    - `_pmp_ajax_create_post( $is_draft )` returns JSON encoding a failure message
    - `_pmp_select_for_post( $post, $type )` returns an empty array
    - `PmpPost::fromPost( $wp_post )` returns the same `PmpPost` object, but created with the same arguments that are used if the post has no PMP GUID
    - `pmp_import_for_saved_queries()` returns false and exits without updating the database's values for the last time the queries were updated or this cron was successfully run.
    - `pmp_get_my_guid( $options )` returns `false`, because the function has the possibility of returning the output of `get_transient`, and the only return from `get_transient` that is not a valid value for a transient is `false`, used by `get_transient` to indicate an error. `pmp_get_my_guid` uses the same `false` to indicate that an error has occurred.
    - `pmp_update_my_guid_transient( $options )` returns `pmp_get_my_guid( $options )` in all cases, rather than returning nothing.
    - `pmp_hourly_cron()` silently exits if the saved options do not pass `pmp_are_settings_valid( $options )`
- Those changes result in changes in their calling functions:
    - `pmp_create_group()`'s output is JSON encoding a failure message if `_pmp_create_doc()` returns false
    - `pmp_modify_group()`'s output is JSON encoding a failure message if `_pmp_modify_doc()` returns false
    - `pmp_get_select_options()`'s output is JSON encoding a failure message if `_pmp_select_for_post()` returns false
- The following functions do **not** change, beyond having an argument passed to the SDKWrapper:
    - `PmpPost->new_doc()`: it's not clear how this function should change, because the whole class depends on access to the API. `PmpPost` extends `PmpSyncer`, which in theory would only be used when the API is enabled, right? 😦 
    - `pmp_post_subscription_data($mode, $topic_url, $settings = array() )` doesn't use the SDKWrapper, but does now have the option to pass a settings array. It continues to return a `WP_Error`. 
    - `pmp_user_title_input()` 
    - `pmp_settings_validate( $input )` passes the input settings to `pmp_send_subscription_request` when subscribing to notifications, and passes the old settings to `pmp_send_subscription_request` when unsubscribing. It also passes the input settings to `pmp_update_my_guid_transient( $input )`
    - `PMPSyncerTestCase::setUpBeforeClass()`
    - `TestAjax::setUp()`
    - `TestSDKWrapper::setUp()`
    - `TestCron::setUp()`
    - `TestFunctions::setUp()`
- All of this plugin's admin pages direct the user to configure the plugin if the plugin is not configured.
   - introduces new file `templates/unconfigured.php` to handle all those cases.
- Adds manual installation instructions for people downloading this plugin from GitHub
- Documentation generally directs people to download this from the WordPress directory
- README.md: now uses correct status badge URLs, after the repo URL changed from PMP to NPR
- Apdates `.bowerrc` to point older Bower clients at the correct server, for the purposes of installing certain dependencies
- Adjusts indentation within `pmp_post_is_mine($post_id)` to be consistent within the function

## Why

Because of https://github.com/npr/pmp-wordpress-plugin/issues/151, where having the SDKWrapper throw an exception when it didn't have the necessary credentials to create a new instance of the SDK revealed that the SDKWrapper was being used in several cases where the plugin was not properly configured.