### PR TITLE
0.2.11 release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Use this plugin to integrate the [Public Media Platform](http://publicmediaplatf
 
 Download this project from the [official Wordpress plugin directory](https://wordpress.org/plugins/public-media-platform/).
 
-Built by the [INN Nerds](http://nerds.inn.org/).
+Built by [INN Labs](https://labs.inn.org/).
 
 ## Table of contents
 

--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,5 @@
 === Public Media Platform ===
-Contributors: publicmediaplatform, innlabs
+Contributors: publicmediaplatform, innlabs, nprds
 Tags: pmp,pubmedia,publicmediaplatform,apm,npr,pri,prx,pbs,media,news
 Requires at least: 4.1
 Tested up to: 4.9

--- a/README.txt
+++ b/README.txt
@@ -63,15 +63,19 @@ See the [documentation on Github](https://github.com/publicmediaplatform/pmp-wor
 
 - Adds support for PHP 7.
 - Removes support for PHP versions before 5.5, and sets a `Requires PHP: 5.5` flag in `readme.txt`.
+- Add support for WordPress versions up to 4.9.
+- Drops support for WordPress versions before 4.1.
 - Updates to [PMP PHP SDK version 2.0.2](https://github.com/npr/pmp-php-sdk/releases/tag/v2.0.2). (Pull request [#143](https://github.com/npr/pmp-wordpress-plugin/pull/143) for issue [#142](https://github.com/npr/pmp-wordpress-plugin/issues/142)) and [#145](https://github.com/npr/pmp-wordpress-plugin/issues/145). Changes affecting this plugin are as follows:
 	- Upgrades to Guzzle 6
 	- Adds support for PHP 7.0 and later
 	- Removes support for PHP versions before 5.5
 	- Provides a new-and-updated PHAR file to bundle in this plugin
+- Allows sites to unset credentials in the plugin admin. (Pull request [#146](https://github.com/npr/pmp-wordpress-plugin/pull/146) for issue [#130](https://github.com/npr/pmp-wordpress-plugin/issues/130).)
 - For PHP 7 compatibility, changes how the `PMP_NOTIFICATIONS_SECRET` constant is defined in order to prevent an "invalid salt" error causing white-screen errors. (Pull request [#144](https://github.com/npr/pmp-wordpress-plugin/pull/144) for [issue #133](https://github.com/npr/pmp-wordpress-plugin/issues/133))
-- Catches a Guzzle runtime exception that prevents the plugin from working properly, and warn users about the cause. ([#134](https://github.com/npr/pmp-wordpress-plugin/pull/134))
-- Changes the default environment of the plugin to the sandbox environment: new installations of the plugin will not automatically use production credentials ([#132](https://github.com/npr/pmp-wordpress-plugin/pull/132))
-- Improved test coverage. ([#131](https://github.com/npr/pmp-wordpress-plugin/pull/131))
+- Catches a Guzzle runtime exception that prevents the plugin from working properly, and warn users about the cause. ([#134](https://github.com/npr/pmp-wordpress-plugin/pull/134)).
+- Changes the default environment of the plugin to the sandbox environment: new installations of the plugin will not automatically use production credentials but must be configured to. ([#132](https://github.com/npr/pmp-wordpress-plugin/pull/132)).
+- Improved test coverage. (Pull request [#131](https://github.com/npr/pmp-wordpress-plugin/pull/131)).
+- Improved documentation for installation through channels other than WordPress.org.
 
 = 0.2.10 =
 

--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,5 @@
 === Public Media Platform ===
-Contributors: publicmediaplatform, inn_nerds
+Contributors: publicmediaplatform, innlabs
 Tags: pmp,pubmedia,publicmediaplatform,apm,npr,pri,prx,pbs,media,news
 Requires at least: 4.1
 Tested up to: 4.9
@@ -16,7 +16,7 @@ The [Public Media Platform](http://publicmediaplatform.org) is a cross-media dis
 
 The PMP was founded by a collaboration of APM, NPR, PBS, PRI and PRX, with the goal of bringing public media content to a wider audience.  It contains more than 300K pieces of digital content from our founding partners, and is growing every day.  For more information on what's available, feel free to [search the PMP](https://support.pmp.io/search?profile=story&has=image).
 
-Built by the [INN Nerds](http://nerds.inn.org/).
+Built by [INN Labs](https://labs.inn.org/).
 
 = Current plugin features: =
 

--- a/fulldocs.md
+++ b/fulldocs.md
@@ -7,7 +7,7 @@ Use this plugin to integrate the [Public Media Platform](http://publicmediaplatf
 
 Also see this project in the [official Wordpress plugin directory](https://wordpress.org/plugins/public-media-platform/).
 
-Built by the [INN Nerds](http://nerds.inn.org/).
+Built by [INN Labs](https://labs.inn.org/).
 
 ## Table of contents
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -325,7 +325,7 @@ function pmp_settings_validate( $input ) {
  *
  * @param Array $settings The settings to be checked
  * @return Boolean Whether or not the settings is valid.
- * @since 0.2.12
+ * @since 0.2.11
  * @link https://github.com/npr/pmp-wordpress-plugin/issues/151
  */
 function pmp_are_settings_valid( $settings_array ) {

--- a/plugin.php
+++ b/plugin.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Plugin Name: Public Media Platform
- * Plugin URI: https://github.com/publicmediaplatform/pmp-wordpress
+ * Plugin URI: https://wordpress.org/plugins/public-media-platform/
  * Description: Integrate your site's content with the <a href="https://support.pmp.io" target="_blank">Public Media Platform</a>.
- * Author: the PMP and INN nerds
+ * Author: NPR and INN Labs
  * Version: 0.2.11
- * Author URI: https://github.com/publicmediaplatform/pmp-wordpress
+ * Author URI: https://github.com/npr/pmp-wordpress-plugin
  * License: MIT
  * Text Domain: pmp
  */


### PR DESCRIPTION
## Changes

- INN Nerds becomes INN Labs
- In the WordPress.org metadata:
    - adds [nprds](https://profiles.wordpress.org/nprds) on WordPress.org as a listed contributor to the plugin
    - changes the plugin URI to point to the wordpress.org plugin page
    - fixes GitHub URLs to the current repo name
- Notes change in supported WordPress versions.